### PR TITLE
feat(rx): add receiver configuration for PPM and ESP modes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -449,6 +449,7 @@ DRONA_SRC = flight/acrobats.cpp \
 			API/User.cpp\
 			API/Motor.cpp\
 			API/API-Utils.cpp\
+			API/RxConfig.cpp\
 			API/Localisation.cpp\
 
 

--- a/src/main/API/PlutoPilot.cpp
+++ b/src/main/API/PlutoPilot.cpp
@@ -1,11 +1,25 @@
 // Do not remove the include below
 #include "PlutoPilot.h"
 
+/**
+ * Configures Pluto's receiver to use PPM or default ESP mode; activate the line matching your setup.
+ * AUX channel configurations is only for PPM recievers if no custom configureMode function is called this are the default setup
+ * ARM mode : Rx_AUX2, range 1300 to 2100
+ * ANGLE mode : Rx_AUX2, range 900 to 2100
+ * BARO mode : Rx_AUX3, range 1300 to 2100
+ * MAG mode : Rx_AUX1, range 900 to 1300
+ * HEADFREE mode : Rx_AUX1, range 1300 to 1700
+ */
+void plutoRxConfig ( void ) {
+  // Receiver mode: Uncomment one line for ESP or PPM setup.
+  Receiver.rxMode ( Rx_ESP );    // Onboard ESP
+  // Receiver.rxMode(Rx_PPM);  // PPM based
+}
+
 // The setup function is called once at Pluto's hardware startup
 void plutoInit ( void ) {
   // Add your hardware initialization code here
 }
-
 
 
 // The function is called once before plutoLoop when you activate Developer Mode
@@ -14,12 +28,10 @@ void onLoopStart ( void ) {
 }
 
 
-
 // The loop function is called in an endless loop
 void plutoLoop ( void ) {
   // Add your repeated code here
 }
-
 
 
 // The function is called once after plutoLoop when you deactivate Developer Mode

--- a/src/main/API/PlutoPilot.h
+++ b/src/main/API/PlutoPilot.h
@@ -18,14 +18,17 @@
 #ifndef _PlutoPilot_H_
 #define _PlutoPilot_H_
 
-#include<stdint.h>
+#include <stdint.h>
+#include "RxConfig.h"
 
-void plutoInit(void);
+void plutoRxConfig ( void );
 
-void onLoopStart(void);
+void plutoInit ( void );
 
-void plutoLoop(void);
+void onLoopStart ( void );
 
-void onLoopFinish(void);
+void plutoLoop ( void );
+
+void onLoopFinish ( void );
 
 #endif

--- a/src/main/API/RxConfig.cpp
+++ b/src/main/API/RxConfig.cpp
@@ -1,0 +1,212 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+
+#include "platform.h"
+
+// #include "build_config.h"
+
+#include "common/color.h"
+#include "common/axis.h"
+#include "common/maths.h"
+
+#include "drivers/sensor.h"
+#include "drivers/accgyro.h"
+#include "drivers/compass.h"
+// #include "drivers/system.h"
+// #include "drivers/gpio.h"
+// #include "drivers/timer.h"
+// #include "drivers/pwm_rx.h"
+#include "drivers/serial.h"
+
+#include "sensors/sensors.h"
+#include "sensors/gyro.h"
+// #include "sensors/compass.h"
+#include "sensors/acceleration.h"
+#include "sensors/barometer.h"
+#include "sensors/boardalignment.h"
+#include "sensors/battery.h"
+
+// #include "io/beeper.h"
+#include "io/serial.h"
+// #include "io/gimbal.h"
+// #include "io/escservo.h"
+#include "io/rc_controls.h"
+// #include "io/rc_curves.h"
+// #include "io/ledstrip.h"
+// #include "io/gps.h"
+
+// #include "rx/rx.h"
+
+#include "telemetry/telemetry.h"
+
+#include "flight/mixer.h"
+#include "flight/pid.h"
+#include "flight/imu.h"
+#include "flight/failsafe.h"
+// #include "flight/altitudehold.h"
+#include "flight/navigation.h"
+// #include "flight/posControl.h"
+// #include "flight/posEstimate.h"
+
+#include "config/runtime_config.h"
+#include "config/config.h"
+
+#include "config/config_profile.h"
+#include "config/config_master.h"
+
+#include "PlutoPilot.h"
+#include "RxConfig.h"
+// #include "config/config_profile.h"
+// #include "config/config_master.h"
+
+
+// #include "io/rc_controls.h"
+
+
+
+rx_mode_e RxMode = Rx_ESP;
+
+/**
+ * Configures auxiliary channels for a specific flight mode.
+ *
+ * @param flightMode The flight mode to configure (e.g., Mode_ARM, Mode_ANGLE).
+ * @param rxChannel The receiver channel associated with the mode.
+ * @param minRange The minimum range value for activation.
+ * @param maxRange The maximum range value for activation.
+ */
+void Rc_Rx_Config_P::configAUX(flight_mode flightMode, rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange) {
+  switch (flightMode) {
+    case Mode_ARM:
+      currentProfile->modeActivationConditions[0] = {(boxId_e)BOXARM, rxChannel - NON_AUX_CHANNEL_COUNT, CHANNEL_VALUE_TO_STEP(minRange), CHANNEL_VALUE_TO_STEP(maxRange)};
+      break;
+    case Mode_ANGLE:
+      currentProfile->modeActivationConditions[1] = {(boxId_e)BOXANGLE, rxChannel - NON_AUX_CHANNEL_COUNT, CHANNEL_VALUE_TO_STEP(minRange), CHANNEL_VALUE_TO_STEP(maxRange)};
+      break;
+    case Mode_BARO:
+      currentProfile->modeActivationConditions[2] = {(boxId_e)BOXBARO, rxChannel - NON_AUX_CHANNEL_COUNT, CHANNEL_VALUE_TO_STEP(minRange), CHANNEL_VALUE_TO_STEP(maxRange)};
+      break;
+    case Mode_MAG:
+      currentProfile->modeActivationConditions[3] = {(boxId_e)BOXMAG, rxChannel - NON_AUX_CHANNEL_COUNT, CHANNEL_VALUE_TO_STEP(minRange), CHANNEL_VALUE_TO_STEP(maxRange)};
+      break;
+    case Mode_HEADFREE:
+      currentProfile->modeActivationConditions[4] = {(boxId_e)BOXHEADFREE, rxChannel - NON_AUX_CHANNEL_COUNT, CHANNEL_VALUE_TO_STEP(minRange), CHANNEL_VALUE_TO_STEP(maxRange)};
+      break;
+    default:
+      break;
+  }
+}
+
+bool AuxChangeEnable = false;
+
+/**
+ * Configures the receiver mode and sets up auxiliary channels accordingly.
+ *
+ * @param rxMode The receiver mode to configure (e.g., Rx_ESP, Rx_PPM).
+ */
+void Rc_Rx_Config_P::rxMode(rx_mode_e rxMode) {
+  switch (rxMode) {
+    case Rx_ESP:
+      AuxChangeEnable = false;
+      featureSet(FEATURE_RX_MSP);
+      featureClear(FEATURE_RX_SERIAL);
+      featureClear(FEATURE_RX_PARALLEL_PWM);
+      featureClear(FEATURE_RX_PPM);
+
+      // Configure auxiliary channels for various modes
+      configAUX(Mode_ARM, Rx_AUX4, 1300, 2100);
+      configAUX(Mode_ANGLE, Rx_AUX4, 900, 2100);
+      configAUX(Mode_BARO, Rx_AUX3, 1300, 2100);
+      configAUX(Mode_MAG, Rx_AUX1, 900, 1300);
+      configAUX(Mode_HEADFREE, Rx_AUX1, 1300, 1700);
+      break;
+
+    case Rx_PPM:
+      AuxChangeEnable = true;
+
+      featureSet(FEATURE_RX_PPM);
+      featureClear(FEATURE_RX_SERIAL);
+      featureClear(FEATURE_RX_PARALLEL_PWM);
+      featureClear(FEATURE_RX_MSP);
+
+      // Configure auxiliary channels for various modes
+      configAUX(Mode_ARM, Rx_AUX2, 1300, 2100);
+      configAUX(Mode_ANGLE, Rx_AUX2, 900, 2100);
+      configAUX(Mode_BARO, Rx_AUX3, 1300, 2100);
+      configAUX(Mode_MAG, Rx_AUX1, 900, 1300);
+      configAUX(Mode_HEADFREE, Rx_AUX1, 1300, 1700);
+      break;
+
+    default:
+      break;
+  }
+}
+
+/**
+ * Configures ARM mode if auxiliary change is enabled.
+ *
+ * @param rxChannel The receiver channel to configure.
+ * @param minRange The minimum range value for activation.
+ * @param maxRange The maximum range value for activation.
+ */
+void Rc_Rx_Config_P::configureArmMode(rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange) {
+  if (AuxChangeEnable) {
+    configAUX(Mode_ARM, rxChannel, minRange, maxRange);
+  }
+}
+
+/**
+ * Configures ANGLE mode if auxiliary change is enabled.
+ *
+ * @param rxChannel The receiver channel to configure.
+ * @param minRange The minimum range value for activation.
+ * @param maxRange The maximum range value for activation.
+ */
+void Rc_Rx_Config_P::configureModeANGLE(rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange) {
+  if (AuxChangeEnable) {
+    configAUX(Mode_ANGLE, rxChannel, minRange, maxRange);
+  }
+}
+
+/**
+ * Configures BARO mode if auxiliary change is enabled.
+ *
+ * @param rxChannel The receiver channel to configure.
+ * @param minRange The minimum range value for activation.
+ * @param maxRange The maximum range value for activation.
+ */
+void Rc_Rx_Config_P::configureModeBARO(rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange) {
+  if (AuxChangeEnable) {
+    configAUX(Mode_BARO, rxChannel, minRange, maxRange);
+  }
+}
+
+/**
+ * Configures MAG mode if auxiliary change is enabled.
+ *
+ * @param rxChannel The receiver channel to configure.
+ * @param minRange The minimum range value for activation.
+ * @param maxRange The maximum range value for activation.
+ */
+void Rc_Rx_Config_P::configureMagMode(rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange) {
+  if (AuxChangeEnable) {
+    configAUX(Mode_MAG, rxChannel, minRange, maxRange);
+  }
+}
+
+/**
+ * Configures HEADFREE mode if auxiliary change is enabled.
+ *
+ * @param rxChannel The receiver channel to configure.
+ * @param minRange The minimum range value for activation.
+ * @param maxRange The maximum range value for activation.
+ */
+void Rc_Rx_Config_P::configureHeadfreeMode(rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange) {
+  if (AuxChangeEnable) {
+    configAUX(Mode_HEADFREE, rxChannel, minRange, maxRange);
+  }
+}
+
+
+Rc_Rx_Config_P Receiver;

--- a/src/main/API/RxConfig.h
+++ b/src/main/API/RxConfig.h
@@ -1,0 +1,50 @@
+#pragma once
+
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+  Rx_ESP,
+  Rx_PPM
+} rx_mode_e;
+
+typedef enum {
+  Mode_ARM,
+  Mode_ANGLE,
+  Mode_BARO,
+  Mode_MAG,
+  Mode_HEADFREE
+} flight_mode;
+
+typedef enum {
+  Rx_AUX1 = 4,
+  Rx_AUX2,
+  Rx_AUX3,
+  Rx_AUX4,
+  Rx_AUX5,
+} rx_channel_e;
+
+
+class Rc_Rx_Config_P {
+ private:
+  void configAUX ( flight_mode flightMode, rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange );
+  
+
+ public:
+  void rxMode ( rx_mode_e rxMode );
+  void configureArmMode ( rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange );
+  void configureModeANGLE ( rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange );
+  void configureModeBARO ( rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange );
+  void configureMagMode ( rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange );
+  void configureHeadfreeMode ( rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange );
+};
+
+extern Rc_Rx_Config_P Receiver;
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/main/config/config.cpp
+++ b/src/main/config/config.cpp
@@ -72,7 +72,10 @@
 #include "config/config_profile.h"
 #include "config/config_master.h"
 
-#define BRUSHED_MOTORS_PWM_RATE 18000
+#include "API/RxConfig.h"
+#include "API/PlutoPilot.h"
+
+#define BRUSHED_MOTORS_PWM_RATE   18000
 #define BRUSHLESS_MOTORS_PWM_RATE 400
 
 #ifdef __cplusplus
@@ -83,56 +86,56 @@ extern "C" {
 }
 #endif
 
-#if !defined(FLASH_SIZE)
-#error "Flash size not defined for target. (specify in KB)"
+#if ! defined( FLASH_SIZE )
+  #error "Flash size not defined for target. (specify in KB)"
 #endif
 
 #ifndef FLASH_PAGE_SIZE
-#ifdef STM32F303xC
-#define FLASH_PAGE_SIZE                 ((uint16_t)0x800)
+  #ifdef STM32F303xC
+    #define FLASH_PAGE_SIZE ( ( uint16_t ) 0x800 )
+  #endif
+
+  #ifdef STM32F10X_MD
+    #define FLASH_PAGE_SIZE ( ( uint16_t ) 0x400 )
+  #endif
+
+  #ifdef STM32F10X_HD
+    #define FLASH_PAGE_SIZE ( ( uint16_t ) 0x800 )
+  #endif
 #endif
 
-#ifdef STM32F10X_MD
-#define FLASH_PAGE_SIZE                 ((uint16_t)0x400)
+#if ! defined( FLASH_SIZE ) && ! defined( FLASH_PAGE_COUNT )
+  #ifdef STM32F10X_MD
+    #define FLASH_PAGE_COUNT 128
+  #endif
+
+  #ifdef STM32F10X_HD
+    #define FLASH_PAGE_COUNT 128
+  #endif
 #endif
 
-#ifdef STM32F10X_HD
-#define FLASH_PAGE_SIZE                 ((uint16_t)0x800)
-#endif
-#endif
-
-#if !defined(FLASH_SIZE) && !defined(FLASH_PAGE_COUNT)
-#ifdef STM32F10X_MD
-#define FLASH_PAGE_COUNT 128
+#if defined( FLASH_SIZE )
+  #define FLASH_PAGE_COUNT ( ( FLASH_SIZE * 0x400 ) / FLASH_PAGE_SIZE )
 #endif
 
-#ifdef STM32F10X_HD
-#define FLASH_PAGE_COUNT 128
-#endif
-#endif
-
-#if defined(FLASH_SIZE)
-#define FLASH_PAGE_COUNT ((FLASH_SIZE * 0x400) / FLASH_PAGE_SIZE)
+#if ! defined( FLASH_PAGE_SIZE )
+  #error "Flash page size not defined for target."
 #endif
 
-#if !defined(FLASH_PAGE_SIZE)
-#error "Flash page size not defined for target."
-#endif
-
-#if !defined(FLASH_PAGE_COUNT)
-#error "Flash page count not defined for target."
+#if ! defined( FLASH_PAGE_COUNT )
+  #error "Flash page count not defined for target."
 #endif
 
 #if FLASH_SIZE <= 128
-#define FLASH_TO_RESERVE_FOR_CONFIG 0x800
+  #define FLASH_TO_RESERVE_FOR_CONFIG 0x800
 #else
-#define FLASH_TO_RESERVE_FOR_CONFIG 0x1000
+  #define FLASH_TO_RESERVE_FOR_CONFIG 0x1000
 #endif
 
 // use the last flash pages for storage
-#define CONFIG_START_FLASH_ADDRESS (0x08000000 + (uint32_t)((FLASH_PAGE_SIZE * FLASH_PAGE_COUNT) - FLASH_TO_RESERVE_FOR_CONFIG))
+#define CONFIG_START_FLASH_ADDRESS ( 0x08000000 + ( uint32_t ) ( ( FLASH_PAGE_SIZE * FLASH_PAGE_COUNT ) - FLASH_TO_RESERVE_FOR_CONFIG ) )
 
-master_t masterConfig;                 // master config struct with data independent from profiles
+master_t masterConfig;    // master config struct with data independent from profiles
 profile_t *currentProfile;
 static uint32_t activeFeaturesLatch = 0;
 
@@ -141,973 +144,902 @@ controlRateConfig_t *currentControlRateProfile;
 
 static const uint8_t EEPROM_CONF_VERSION = 106;
 
-static void resetAccelerometerTrims(flightDynamicsTrims_t *accelerometerTrims)
-{
-    accelerometerTrims->values.pitch = 0;
-    accelerometerTrims->values.roll = 0;
-    accelerometerTrims->values.yaw = 0;
+static void resetAccelerometerTrims ( flightDynamicsTrims_t *accelerometerTrims ) {
+  accelerometerTrims->values.pitch = 0;
+  accelerometerTrims->values.roll  = 0;
+  accelerometerTrims->values.yaw   = 0;
 }
 
-static void resetAccelerometerCalibration(flightAccelCalData_T *flightAccelCalData)
-{
-    flightAccelCalData->accel_offset[0] = 0;
-    flightAccelCalData->accel_offset[1] = 0;
-    flightAccelCalData->accel_offset[2] = 0;
+static void resetAccelerometerCalibration ( flightAccelCalData_T *flightAccelCalData ) {
+  flightAccelCalData->accel_offset [ 0 ] = 0;
+  flightAccelCalData->accel_offset [ 1 ] = 0;
+  flightAccelCalData->accel_offset [ 2 ] = 0;
 
-    flightAccelCalData->accel_scale[0] = 1;
-    flightAccelCalData->accel_scale[1] = 1;
-    flightAccelCalData->accel_scale[2] = 1;
+  flightAccelCalData->accel_scale [ 0 ] = 1;
+  flightAccelCalData->accel_scale [ 1 ] = 1;
+  flightAccelCalData->accel_scale [ 2 ] = 1;
 }
 
-static void resetPidProfile(pidProfile_t *pidProfile)
-{
-    pidProfile->pidController = 1;
+static void resetPidProfile ( pidProfile_t *pidProfile ) {
+  pidProfile->pidController = 1;
 
-    pidProfile->P8[PIDROLL] = 40; //38; //40; //40 10 30
-    pidProfile->I8[PIDROLL] = 10; //35; //30;
-    pidProfile->D8[PIDROLL] = 30; //23;
-    pidProfile->P8[PIDPITCH] = 40;  //38; //40; //40 10 30
-    pidProfile->I8[PIDPITCH] = 10;  //35; //30;
-    pidProfile->D8[PIDPITCH] = 30; //23;
-    pidProfile->P8[PIDYAW] = 150; //85;
-    pidProfile->I8[PIDYAW] = 70; //45;
-    pidProfile->D8[PIDYAW] = 50; //0;
-    pidProfile->P8[PIDALT] = 100;
-    pidProfile->I8[PIDALT] = 0;
-    pidProfile->D8[PIDALT] = 30; //0;
+  pidProfile->P8 [ PIDROLL ]  = 40;     // 38; //40; //40 10 30
+  pidProfile->I8 [ PIDROLL ]  = 10;     // 35; //30;
+  pidProfile->D8 [ PIDROLL ]  = 30;     // 23;
+  pidProfile->P8 [ PIDPITCH ] = 40;     // 38; //40; //40 10 30
+  pidProfile->I8 [ PIDPITCH ] = 10;     // 35; //30;
+  pidProfile->D8 [ PIDPITCH ] = 30;     // 23;
+  pidProfile->P8 [ PIDYAW ]   = 150;    // 85;
+  pidProfile->I8 [ PIDYAW ]   = 70;     // 45;
+  pidProfile->D8 [ PIDYAW ]   = 50;     // 0;
+  pidProfile->P8 [ PIDALT ]   = 100;
+  pidProfile->I8 [ PIDALT ]   = 0;
+  pidProfile->D8 [ PIDALT ]   = 30;     // 0;
 
-    pidProfile->P8[PIDPOS] = 80; // POSHOLD_P * 100;
-    pidProfile->I8[PIDPOS] = 0; // POSHOLD_I * 100;
-    pidProfile->D8[PIDPOS] = 0;
+  pidProfile->P8 [ PIDPOS ] = 80;       // POSHOLD_P * 100;
+  pidProfile->I8 [ PIDPOS ] = 0;        // POSHOLD_I * 100;
+  pidProfile->D8 [ PIDPOS ] = 0;
 
-    pidProfile->P8[PIDPOSR] = 30; // POSHOLD_RATE_P * 10;
-    pidProfile->I8[PIDPOSR] = 2; // POSHOLD_RATE_I * 100;
-    pidProfile->D8[PIDPOSR] = 5; // POSHOLD_RATE_D * 1000;
+  pidProfile->P8 [ PIDPOSR ] = 30;      // POSHOLD_RATE_P * 10;
+  pidProfile->I8 [ PIDPOSR ] = 2;       // POSHOLD_RATE_I * 100;
+  pidProfile->D8 [ PIDPOSR ] = 5;       // POSHOLD_RATE_D * 1000;
 
-    pidProfile->P8[PIDNAVR] = 25; // NAV_P * 10;
-    pidProfile->I8[PIDNAVR] = 33; // NAV_I * 100;
-    pidProfile->D8[PIDNAVR] = 83; // NAV_D * 1000;
+  pidProfile->P8 [ PIDNAVR ] = 25;      // NAV_P * 10;
+  pidProfile->I8 [ PIDNAVR ] = 33;      // NAV_I * 100;
+  pidProfile->D8 [ PIDNAVR ] = 83;      // NAV_D * 1000;
 
-    pidProfile->P8[PIDLEVEL] = 40; //90;
-    pidProfile->I8[PIDLEVEL] = 10;
-    pidProfile->D8[PIDLEVEL] = 100;
-    pidProfile->P8[PIDMAG] = 40;
-    pidProfile->P8[PIDVEL] = 120;  //120  //40
-    pidProfile->I8[PIDVEL] = 45;  //45    //20
-    pidProfile->D8[PIDVEL] = 1;  //1      //0
+  pidProfile->P8 [ PIDLEVEL ] = 40;     // 90;
+  pidProfile->I8 [ PIDLEVEL ] = 10;
+  pidProfile->D8 [ PIDLEVEL ] = 100;
+  pidProfile->P8 [ PIDMAG ]   = 40;
+  pidProfile->P8 [ PIDVEL ]   = 120;    // 120  //40
+  pidProfile->I8 [ PIDVEL ]   = 45;     // 45    //20
+  pidProfile->D8 [ PIDVEL ]   = 1;      // 1      //0
 
-    pidProfile->P8[PIDUSER] = 60;
-    pidProfile->I8[PIDUSER] = 30;
-    pidProfile->D8[PIDUSER] = 5;
+  pidProfile->P8 [ PIDUSER ] = 60;
+  pidProfile->I8 [ PIDUSER ] = 30;
+  pidProfile->D8 [ PIDUSER ] = 5;
 
-    pidProfile->yaw_p_limit = YAW_P_LIMIT_MAX;
-    pidProfile->dterm_cut_hz = 0;
-    pidProfile->pterm_cut_hz = 0;
-    pidProfile->gyro_cut_hz = 0;
+  pidProfile->yaw_p_limit  = YAW_P_LIMIT_MAX;
+  pidProfile->dterm_cut_hz = 0;
+  pidProfile->pterm_cut_hz = 0;
+  pidProfile->gyro_cut_hz  = 0;
 
-    pidProfile->P_f[ROLL] = 1.5f;     // new PID with preliminary defaults test carefully
-    pidProfile->I_f[ROLL] = 0.4f;
-    pidProfile->D_f[ROLL] = 0.03f;
-    pidProfile->P_f[PITCH] = 1.5f;
-    pidProfile->I_f[PITCH] = 0.4f;
-    pidProfile->D_f[PITCH] = 0.03f;
-    pidProfile->P_f[YAW] = 2.5f;
-    pidProfile->I_f[YAW] = 1.0f;
-    pidProfile->D_f[YAW] = 0.00f;
-    pidProfile->A_level = 5.0f;
-    pidProfile->H_level = 3.0f;
-    pidProfile->H_sensitivity = 75;
+  pidProfile->P_f [ ROLL ]  = 1.5f;    // new PID with preliminary defaults test carefully
+  pidProfile->I_f [ ROLL ]  = 0.4f;
+  pidProfile->D_f [ ROLL ]  = 0.03f;
+  pidProfile->P_f [ PITCH ] = 1.5f;
+  pidProfile->I_f [ PITCH ] = 0.4f;
+  pidProfile->D_f [ PITCH ] = 0.03f;
+  pidProfile->P_f [ YAW ]   = 2.5f;
+  pidProfile->I_f [ YAW ]   = 1.0f;
+  pidProfile->D_f [ YAW ]   = 0.00f;
+  pidProfile->A_level       = 5.0f;
+  pidProfile->H_level       = 3.0f;
+  pidProfile->H_sensitivity = 75;
 
-    pidProfile->pid5_oldyw = 0;
+  pidProfile->pid5_oldyw = 0;
 
 #ifdef GTUNE
-    pidProfile->gtune_lolimP[ROLL] = 10;          // [0..200] Lower limit of ROLL P during G tune.
-    pidProfile->gtune_lolimP[PITCH] = 10;// [0..200] Lower limit of PITCH P during G tune.
-    pidProfile->gtune_lolimP[YAW] = 10;// [0..200] Lower limit of YAW P during G tune.
-    pidProfile->gtune_hilimP[ROLL] = 100;// [0..200] Higher limit of ROLL P during G tune. 0 Disables tuning for that axis.
-    pidProfile->gtune_hilimP[PITCH] = 100;// [0..200] Higher limit of PITCH P during G tune. 0 Disables tuning for that axis.
-    pidProfile->gtune_hilimP[YAW] = 100;// [0..200] Higher limit of YAW P during G tune. 0 Disables tuning for that axis.
-    pidProfile->gtune_pwr = 0;// [0..10] Strength of adjustment
-    pidProfile->gtune_settle_time = 450;// [200..1000] Settle time in ms
-    pidProfile->gtune_average_cycles = 16;// [8..128] Number of looptime cycles used for gyro average calculation
+  pidProfile->gtune_lolimP [ ROLL ]  = 10;     // [0..200] Lower limit of ROLL P during G tune.
+  pidProfile->gtune_lolimP [ PITCH ] = 10;     // [0..200] Lower limit of PITCH P during G tune.
+  pidProfile->gtune_lolimP [ YAW ]   = 10;     // [0..200] Lower limit of YAW P during G tune.
+  pidProfile->gtune_hilimP [ ROLL ]  = 100;    // [0..200] Higher limit of ROLL P during G tune. 0 Disables tuning for that axis.
+  pidProfile->gtune_hilimP [ PITCH ] = 100;    // [0..200] Higher limit of PITCH P during G tune. 0 Disables tuning for that axis.
+  pidProfile->gtune_hilimP [ YAW ]   = 100;    // [0..200] Higher limit of YAW P during G tune. 0 Disables tuning for that axis.
+  pidProfile->gtune_pwr              = 0;      // [0..10] Strength of adjustment
+  pidProfile->gtune_settle_time      = 450;    // [200..1000] Settle time in ms
+  pidProfile->gtune_average_cycles   = 16;     // [8..128] Number of looptime cycles used for gyro average calculation
 #endif
 }
 
 #ifdef GPS
-void resetGpsProfile(gpsProfile_t *gpsProfile)
-{
-    gpsProfile->gps_wp_radius = 200;
-    gpsProfile->gps_lpf = 20;
-    gpsProfile->nav_slew_rate = 30; //30 was default
-    gpsProfile->nav_controls_heading = 1;
-    gpsProfile->nav_speed_min = 100;
-    gpsProfile->nav_speed_max = 300;
-    gpsProfile->ap_mode = 40;
+void resetGpsProfile ( gpsProfile_t *gpsProfile ) {
+  gpsProfile->gps_wp_radius        = 200;
+  gpsProfile->gps_lpf              = 20;
+  gpsProfile->nav_slew_rate        = 30;    // 30 was default
+  gpsProfile->nav_controls_heading = 1;
+  gpsProfile->nav_speed_min        = 100;
+  gpsProfile->nav_speed_max        = 300;
+  gpsProfile->ap_mode              = 40;
 }
 #endif
 
-void resetBarometerConfig(barometerConfig_t *barometerConfig)
-{
-    barometerConfig->baro_sample_count = 21;
-    barometerConfig->baro_noise_lpf = 0.6f;
-    barometerConfig->baro_cf_vel = 0.985f;
-    barometerConfig->baro_cf_alt = 0.92f;
+void resetBarometerConfig ( barometerConfig_t *barometerConfig ) {
+  barometerConfig->baro_sample_count = 21;
+  barometerConfig->baro_noise_lpf    = 0.6f;
+  barometerConfig->baro_cf_vel       = 0.985f;
+  barometerConfig->baro_cf_alt       = 0.92f;
 }
 
-void resetSensorAlignment(sensorAlignmentConfig_t *sensorAlignmentConfig)
-{
-    sensorAlignmentConfig->gyro_align = ALIGN_DEFAULT;
-    sensorAlignmentConfig->acc_align = ALIGN_DEFAULT;
-    sensorAlignmentConfig->mag_align = ALIGN_DEFAULT;
+void resetSensorAlignment ( sensorAlignmentConfig_t *sensorAlignmentConfig ) {
+  sensorAlignmentConfig->gyro_align = ALIGN_DEFAULT;
+  sensorAlignmentConfig->acc_align  = ALIGN_DEFAULT;
+  sensorAlignmentConfig->mag_align  = ALIGN_DEFAULT;
 }
 
-void resetEscAndServoConfig(escAndServoConfig_t *escAndServoConfig)
-{
-    escAndServoConfig->minthrottle = 1100;
-    escAndServoConfig->maxthrottle = 2000;
-    escAndServoConfig->mincommand = 1000;
-    escAndServoConfig->servoCenterPulse = 1500;
+void resetEscAndServoConfig ( escAndServoConfig_t *escAndServoConfig ) {
+  escAndServoConfig->minthrottle      = 1100;
+  escAndServoConfig->maxthrottle      = 2000;
+  escAndServoConfig->mincommand       = 1000;
+  escAndServoConfig->servoCenterPulse = 1500;
 }
 
-void resetFlight3DConfig(flight3DConfig_t *flight3DConfig)
-{
-    flight3DConfig->deadband3d_low = 1406;
-    flight3DConfig->deadband3d_high = 1514;
-    flight3DConfig->neutral3d = 1460;
-    flight3DConfig->deadband3d_throttle = 50;
+void resetFlight3DConfig ( flight3DConfig_t *flight3DConfig ) {
+  flight3DConfig->deadband3d_low      = 1406;
+  flight3DConfig->deadband3d_high     = 1514;
+  flight3DConfig->neutral3d           = 1460;
+  flight3DConfig->deadband3d_throttle = 50;
 }
 
-void resetTelemetryConfig(telemetryConfig_t *telemetryConfig)
-{
-    telemetryConfig->telemetry_inversion = 0;
-    telemetryConfig->telemetry_switch = 0;
-    telemetryConfig->gpsNoFixLatitude = 0;
-    telemetryConfig->gpsNoFixLongitude = 0;
-    telemetryConfig->frsky_coordinate_format = FRSKY_FORMAT_DMS;
-    telemetryConfig->frsky_unit = FRSKY_UNIT_METRICS;
-    telemetryConfig->frsky_vfas_precision = 0;
-    telemetryConfig->hottAlarmSoundInterval = 5;
+void resetTelemetryConfig ( telemetryConfig_t *telemetryConfig ) {
+  telemetryConfig->telemetry_inversion     = 0;
+  telemetryConfig->telemetry_switch        = 0;
+  telemetryConfig->gpsNoFixLatitude        = 0;
+  telemetryConfig->gpsNoFixLongitude       = 0;
+  telemetryConfig->frsky_coordinate_format = FRSKY_FORMAT_DMS;
+  telemetryConfig->frsky_unit              = FRSKY_UNIT_METRICS;
+  telemetryConfig->frsky_vfas_precision    = 0;
+  telemetryConfig->hottAlarmSoundInterval  = 5;
 }
 
-void resetBatteryConfig(batteryConfig_t *batteryConfig)
-{
-    batteryConfig->vbatscale = VBAT_SCALE_DEFAULT;
-    batteryConfig->vbatresdivval = VBAT_RESDIVVAL_DEFAULT;
-    batteryConfig->vbatresdivmultiplier = VBAT_RESDIVMULTIPLIER_DEFAULT;
-    batteryConfig->vbatmaxcellvoltage = 43; //43
-    batteryConfig->vbatmincellvoltage = 35; //33
-    batteryConfig->vbatwarningcellvoltage = 36; //35
-    batteryConfig->currentMeterOffset = 16; //pluto default 0
-    batteryConfig->currentMeterScale = 30; // for Allegro ACS758LCB-100U (40mV/A)     CHANGED for pluto, 400 default
-    batteryConfig->batteryCapacity = 350;
-    batteryConfig->currentMeterType = CURRENT_SENSOR_VIRTUAL; //ADC to VIRTUAL
+void resetBatteryConfig ( batteryConfig_t *batteryConfig ) {
+  batteryConfig->vbatscale              = VBAT_SCALE_DEFAULT;
+  batteryConfig->vbatresdivval          = VBAT_RESDIVVAL_DEFAULT;
+  batteryConfig->vbatresdivmultiplier   = VBAT_RESDIVMULTIPLIER_DEFAULT;
+  batteryConfig->vbatmaxcellvoltage     = 43;                        // 43
+  batteryConfig->vbatmincellvoltage     = 35;                        // 33
+  batteryConfig->vbatwarningcellvoltage = 36;                        // 35
+  batteryConfig->currentMeterOffset     = 16;                        // pluto default 0
+  batteryConfig->currentMeterScale      = 30;                        // for Allegro ACS758LCB-100U (40mV/A)     CHANGED for pluto, 400 default
+  batteryConfig->batteryCapacity        = 350;
+  batteryConfig->currentMeterType       = CURRENT_SENSOR_VIRTUAL;    // ADC to VIRTUAL
 }
 
 #ifdef SWAP_SERIAL_PORT_0_AND_1_DEFAULTS
-#define FIRST_PORT_INDEX 1
-#define SECOND_PORT_INDEX 0
+  #define FIRST_PORT_INDEX  1
+  #define SECOND_PORT_INDEX 0
 #else
-#define FIRST_PORT_INDEX 0
-#define SECOND_PORT_INDEX 1
+  #define FIRST_PORT_INDEX  0
+  #define SECOND_PORT_INDEX 1
 #endif
 
-void resetSerialConfig(serialConfig_t *serialConfig)
-{
-    uint8_t index;
-    memset(serialConfig, 0, sizeof(serialConfig_t));
+void resetSerialConfig ( serialConfig_t *serialConfig ) {
+  uint8_t index;
+  memset ( serialConfig, 0, sizeof ( serialConfig_t ) );
 
-    for (index = 0; index < SERIAL_PORT_COUNT; index++) {
-        serialConfig->portConfigs[index].identifier = serialPortIdentifiers[index];
-        serialConfig->portConfigs[index].msp_baudrateIndex = BAUD_115200;
-        serialConfig->portConfigs[index].gps_baudrateIndex = BAUD_9600;
-        serialConfig->portConfigs[index].telemetry_baudrateIndex = BAUD_AUTO;
-        serialConfig->portConfigs[index].blackbox_baudrateIndex = BAUD_115200;
-    }
+  for ( index = 0; index < SERIAL_PORT_COUNT; index++ ) {
+    serialConfig->portConfigs [ index ].identifier              = serialPortIdentifiers [ index ];
+    serialConfig->portConfigs [ index ].msp_baudrateIndex       = BAUD_115200;
+    serialConfig->portConfigs [ index ].gps_baudrateIndex       = BAUD_9600;
+    serialConfig->portConfigs [ index ].telemetry_baudrateIndex = BAUD_AUTO;
+    serialConfig->portConfigs [ index ].blackbox_baudrateIndex  = BAUD_115200;
+  }
 
-    serialConfig->portConfigs[0].functionMask = FUNCTION_MSP;
-    serialConfig->portConfigs[1].functionMask = FUNCTION_GPS;
+  serialConfig->portConfigs [ 0 ].functionMask = FUNCTION_MSP;
+  serialConfig->portConfigs [ 1 ].functionMask = FUNCTION_GPS;
 
 #ifdef CC3D
-    // This allows MSP connection via USART & VCP so the board can be reconfigured.
-    serialConfig->portConfigs[1].functionMask = FUNCTION_MSP;
+  // This allows MSP connection via USART & VCP so the board can be reconfigured.
+  serialConfig->portConfigs [ 1 ].functionMask = FUNCTION_MSP;
 #endif
 
-    serialConfig->reboot_character = 'R';
+  serialConfig->reboot_character = 'R';
 }
 
-static void resetControlRateConfig(controlRateConfig_t *controlRateConfig)
-{
-    controlRateConfig->rcRate8 = 90;
-    controlRateConfig->rcExpo8 = 65;
-    controlRateConfig->thrMid8 = 50;
-    controlRateConfig->thrExpo8 = 0;
-    controlRateConfig->dynThrPID = 0;
-    controlRateConfig->rcYawExpo8 = 0;
-    controlRateConfig->tpa_breakpoint = 1500;
+static void resetControlRateConfig ( controlRateConfig_t *controlRateConfig ) {
+  controlRateConfig->rcRate8        = 90;
+  controlRateConfig->rcExpo8        = 65;
+  controlRateConfig->thrMid8        = 50;
+  controlRateConfig->thrExpo8       = 0;
+  controlRateConfig->dynThrPID      = 0;
+  controlRateConfig->rcYawExpo8     = 0;
+  controlRateConfig->tpa_breakpoint = 1500;
 
-    for (uint8_t axis = 0; axis < FLIGHT_DYNAMICS_INDEX_COUNT; axis++) {
-        controlRateConfig->rates[axis] = 0;
-    }
-
+  for ( uint8_t axis = 0; axis < FLIGHT_DYNAMICS_INDEX_COUNT; axis++ ) {
+    controlRateConfig->rates [ axis ] = 0;
+  }
 }
 
-void resetRcControlsConfig(rcControlsConfig_t *rcControlsConfig)
-{
-    rcControlsConfig->deadband = 0;
-    rcControlsConfig->yaw_deadband = 0; //80;
-    rcControlsConfig->alt_hold_deadband = 40;
-    rcControlsConfig->alt_hold_fast_change = 0; // Drona test
+void resetRcControlsConfig ( rcControlsConfig_t *rcControlsConfig ) {
+  rcControlsConfig->deadband             = 0;
+  rcControlsConfig->yaw_deadband         = 0;    // 80;
+  rcControlsConfig->alt_hold_deadband    = 40;
+  rcControlsConfig->alt_hold_fast_change = 0;    // Drona test
 }
 
-void resetMixerConfig(mixerConfig_t *mixerConfig)
-{
-    mixerConfig->pid_at_min_throttle = 1;
-    mixerConfig->yaw_motor_direction = 1;
-    mixerConfig->yaw_jump_prevention_limit = 200;
+void resetMixerConfig ( mixerConfig_t *mixerConfig ) {
+  mixerConfig->pid_at_min_throttle       = 1;
+  mixerConfig->yaw_motor_direction       = 1;
+  mixerConfig->yaw_jump_prevention_limit = 200;
 #ifdef USE_MIXER_SERVOS
-    mixerConfig->tri_unarmed_servo = 1;
-    mixerConfig->servo_lowpass_freq = 400;
-    mixerConfig->servo_lowpass_enable = 0;
+  mixerConfig->tri_unarmed_servo    = 1;
+  mixerConfig->servo_lowpass_freq   = 400;
+  mixerConfig->servo_lowpass_enable = 0;
 #endif
 }
 
-uint8_t getCurrentProfile(void)
-{
-    return masterConfig.current_profile_index;
+uint8_t getCurrentProfile ( void ) {
+  return masterConfig.current_profile_index;
 }
 
-static void setProfile(uint8_t profileIndex)
-{
-    currentProfile = &masterConfig.profile[profileIndex];
+static void setProfile ( uint8_t profileIndex ) {
+  currentProfile = &masterConfig.profile [ profileIndex ];
 }
 
-uint8_t getCurrentControlRateProfile(void)
-{
-    return currentControlRateProfileIndex;
+uint8_t getCurrentControlRateProfile ( void ) {
+  return currentControlRateProfileIndex;
 }
 
-controlRateConfig_t *getControlRateConfig(uint8_t profileIndex)
-{
-    return &masterConfig.controlRateProfiles[profileIndex];
+controlRateConfig_t *getControlRateConfig ( uint8_t profileIndex ) {
+  return &masterConfig.controlRateProfiles [ profileIndex ];
 }
 
-static void setControlRateProfile(uint8_t profileIndex)
-{
-    currentControlRateProfileIndex = profileIndex;
-    currentControlRateProfile = &masterConfig.controlRateProfiles[profileIndex];
+static void setControlRateProfile ( uint8_t profileIndex ) {
+  currentControlRateProfileIndex = profileIndex;
+  currentControlRateProfile      = &masterConfig.controlRateProfiles [ profileIndex ];
 }
 
-uint16_t getCurrentMinthrottle(void)
-{
-    return masterConfig.escAndServoConfig.minthrottle;
+uint16_t getCurrentMinthrottle ( void ) {
+  return masterConfig.escAndServoConfig.minthrottle;
 }
 
 // Default settings
-static void resetConf(void)
-{
-    int i;
+static void resetConf ( void ) {
+  int i;
 
-    // Clear all configuration
-    memset(&masterConfig, 0, sizeof(master_t));
-    setProfile(0);
-    setControlRateProfile(0);
+  // Clear all configuration
+  memset ( &masterConfig, 0, sizeof ( master_t ) );
+  setProfile ( 0 );
+  setControlRateProfile ( 0 );
 
-    masterConfig.version = EEPROM_CONF_VERSION;
-    masterConfig.mixerMode = MIXER_QUADX;
-    //    masterConfig.mixerMode = MIXER_QUADP;
-    featureClearAll();
-#if defined(CJMCU) ||  defined(PRIMUSV3R) || defined(SPARKY) || defined(COLIBRI_RACE) || defined(MOTOLAB) || defined(ALIENWIIF3) ||  defined(PRIMUSX) || defined(PRIMUSX2)
-    //featureSet(FEATURE_RX_PPM);
-    featureSet(FEATURE_RX_MSP);
-    featureSet(FEATURE_CURRENT_METER);//testing virtual adc current measurement
-    featureSet(FEATURE_GPS);
+  masterConfig.version   = EEPROM_CONF_VERSION;
+  masterConfig.mixerMode = MIXER_QUADX;
+  //    masterConfig.mixerMode = MIXER_QUADP;
+  featureClearAll ( );
+#if defined( CJMCU ) || defined( PRIMUSV3R ) || defined( SPARKY ) || defined( COLIBRI_RACE ) || defined( MOTOLAB ) || defined( ALIENWIIF3 ) || defined( PRIMUSX ) || defined( PRIMUSX2 )
+  featureSet ( FEATURE_CURRENT_METER );    // testing virtual adc current measurement
+  featureSet ( FEATURE_GPS );
 #endif
 
 #ifdef BOARD_HAS_VOLTAGE_DIVIDER
-    // only enable the VBAT feature by default if the board has a voltage divider otherwise
-    // the user may see incorrect readings and unexpected issues with pin mappings may occur.
-    featureSet(FEATURE_VBAT);
+  // only enable the VBAT feature by default if the board has a voltage divider otherwise
+  // the user may see incorrect readings and unexpected issues with pin mappings may occur.
+  featureSet ( FEATURE_VBAT );
 #endif
 
-    featureSet(FEATURE_FAILSAFE);
+  featureSet ( FEATURE_FAILSAFE );
 
-    // global settings
-    masterConfig.current_profile_index = 0;     // default profile
-    masterConfig.gyro_cmpf_factor = 600;        // default MWC
-    masterConfig.gyro_cmpfm_factor = 250;       // default MWC
-    masterConfig.gyro_lpf = 42;   // supported by all gyro drivers now. In case of ST gyro, will default to 32Hz instead
+  // global settings
+  masterConfig.current_profile_index = 0;      // default profile
+  masterConfig.gyro_cmpf_factor      = 600;    // default MWC
+  masterConfig.gyro_cmpfm_factor     = 250;    // default MWC
+  masterConfig.gyro_lpf              = 42;     // supported by all gyro drivers now. In case of ST gyro, will default to 32Hz instead
 
-    resetAccelerometerTrims(&masterConfig.accZero);
-    resetAccelerometerCalibration(&masterConfig.accCalData);
+  resetAccelerometerTrims ( &masterConfig.accZero );
+  resetAccelerometerCalibration ( &masterConfig.accCalData );
 
-    resetSensorAlignment(&masterConfig.sensorAlignmentConfig);
+  resetSensorAlignment ( &masterConfig.sensorAlignmentConfig );
 
-    masterConfig.boardAlignment.rollDegrees = 0;
-    masterConfig.boardAlignment.pitchDegrees = 0;
-    masterConfig.boardAlignment.yawDegrees = 0;
-    masterConfig.acc_hardware = ACC_DEFAULT;     // default/autodetect
-    masterConfig.max_angle_inclination = 200; //drona   // 50 degrees  Drona
-    masterConfig.yaw_control_direction = 1;
-    masterConfig.gyroConfig.gyroMovementCalibrationThreshold = 32;
+  masterConfig.boardAlignment.rollDegrees                  = 0;
+  masterConfig.boardAlignment.pitchDegrees                 = 0;
+  masterConfig.boardAlignment.yawDegrees                   = 0;
+  masterConfig.acc_hardware                                = ACC_DEFAULT;    // default/autodetect
+  masterConfig.max_angle_inclination                       = 200;            // drona   // 50 degrees  Drona
+  masterConfig.yaw_control_direction                       = 1;
+  masterConfig.gyroConfig.gyroMovementCalibrationThreshold = 32;
 
-    masterConfig.mag_hardware = MAG_DEFAULT;     // default/autodetect
-    masterConfig.baro_hardware = BARO_DEFAULT;   // default/autodetect
+  masterConfig.mag_hardware  = MAG_DEFAULT;     // default/autodetect
+  masterConfig.baro_hardware = BARO_DEFAULT;    // default/autodetect
 
-    resetBatteryConfig(&masterConfig.batteryConfig);
+  resetBatteryConfig ( &masterConfig.batteryConfig );
 
-    resetTelemetryConfig(&masterConfig.telemetryConfig);
+  resetTelemetryConfig ( &masterConfig.telemetryConfig );
 
-    masterConfig.rxConfig.serialrx_provider = 0;
-    masterConfig.rxConfig.spektrum_sat_bind = 0;
-    masterConfig.rxConfig.midrc = 1500;
-    masterConfig.rxConfig.mincheck = 1100;
-    masterConfig.rxConfig.maxcheck = 1900;
-    masterConfig.rxConfig.rx_min_usec = 885;  // any of first 4 channels below this value will trigger rx loss detection
-    masterConfig.rxConfig.rx_max_usec = 2115; // any of first 4 channels above this value will trigger rx loss detection
+  masterConfig.rxConfig.serialrx_provider = 0;
+  masterConfig.rxConfig.spektrum_sat_bind = 0;
+  masterConfig.rxConfig.midrc             = 1500;
+  masterConfig.rxConfig.mincheck          = 1100;
+  masterConfig.rxConfig.maxcheck          = 1900;
+  masterConfig.rxConfig.rx_min_usec       = 885;     // any of first 4 channels below this value will trigger rx loss detection
+  masterConfig.rxConfig.rx_max_usec       = 2115;    // any of first 4 channels above this value will trigger rx loss detection
 
-    for (i = 0; i < MAX_SUPPORTED_RC_CHANNEL_COUNT; i++) {
-        rxFailsafeChannelConfiguration_t *channelFailsafeConfiguration = &masterConfig.rxConfig.failsafe_channel_configurations[i];
-        channelFailsafeConfiguration->mode = (i < NON_AUX_CHANNEL_COUNT) ? RX_FAILSAFE_MODE_AUTO : RX_FAILSAFE_MODE_HOLD;
-        channelFailsafeConfiguration->step =
-                (i == THROTTLE) ? CHANNEL_VALUE_TO_RXFAIL_STEP(masterConfig.rxConfig.rx_min_usec) : CHANNEL_VALUE_TO_RXFAIL_STEP(masterConfig.rxConfig.midrc);
-    }
+  for ( i = 0; i < MAX_SUPPORTED_RC_CHANNEL_COUNT; i++ ) {
+    rxFailsafeChannelConfiguration_t *channelFailsafeConfiguration = &masterConfig.rxConfig.failsafe_channel_configurations [ i ];
+    channelFailsafeConfiguration->mode                             = ( i < NON_AUX_CHANNEL_COUNT ) ? RX_FAILSAFE_MODE_AUTO : RX_FAILSAFE_MODE_HOLD;
+    channelFailsafeConfiguration->step                             = ( i == THROTTLE ) ? CHANNEL_VALUE_TO_RXFAIL_STEP ( masterConfig.rxConfig.rx_min_usec ) : CHANNEL_VALUE_TO_RXFAIL_STEP ( masterConfig.rxConfig.midrc );
+  }
 
-    masterConfig.rxConfig.rssi_channel = 0;
-    masterConfig.rxConfig.rssi_scale = RSSI_SCALE_DEFAULT;
-    masterConfig.rxConfig.rssi_ppm_invert = 0;
-    masterConfig.rxConfig.rcSmoothing = 1;         //Drona temp rc filter
+  masterConfig.rxConfig.rssi_channel    = 0;
+  masterConfig.rxConfig.rssi_scale      = RSSI_SCALE_DEFAULT;
+  masterConfig.rxConfig.rssi_ppm_invert = 0;
+  masterConfig.rxConfig.rcSmoothing     = 1;    // Drona temp rc filter
 
-    resetAllRxChannelRangeConfigurations(masterConfig.rxConfig.channelRanges);
+  resetAllRxChannelRangeConfigurations ( masterConfig.rxConfig.channelRanges );
 
-    masterConfig.inputFilteringMode = INPUT_FILTERING_DISABLED;
+  masterConfig.inputFilteringMode = INPUT_FILTERING_DISABLED;
 
-    masterConfig.retarded_arm = 0;
-    masterConfig.disarm_kill_switch = 1;
-    masterConfig.auto_disarm_delay = 5;
-    masterConfig.small_angle = 150;
+  masterConfig.retarded_arm       = 0;
+  masterConfig.disarm_kill_switch = 1;
+  masterConfig.auto_disarm_delay  = 5;
+  masterConfig.small_angle        = 150;
 
-    resetMixerConfig(&masterConfig.mixerConfig);
+  resetMixerConfig ( &masterConfig.mixerConfig );
 
-    masterConfig.airplaneConfig.fixedwing_althold_dir = 1;
+  masterConfig.airplaneConfig.fixedwing_althold_dir = 1;
 
-    // Motor/ESC/Servo
-    resetEscAndServoConfig(&masterConfig.escAndServoConfig);
-    resetFlight3DConfig(&masterConfig.flight3DConfig);
+  // Motor/ESC/Servo
+  resetEscAndServoConfig ( &masterConfig.escAndServoConfig );
+  resetFlight3DConfig ( &masterConfig.flight3DConfig );
 
 #ifdef BRUSHED_MOTORS
-    masterConfig.motor_pwm_rate = BRUSHED_MOTORS_PWM_RATE;
+  masterConfig.motor_pwm_rate = BRUSHED_MOTORS_PWM_RATE;
 #else
-    masterConfig.motor_pwm_rate = BRUSHLESS_MOTORS_PWM_RATE;
+  masterConfig.motor_pwm_rate = BRUSHLESS_MOTORS_PWM_RATE;
 #endif
-    masterConfig.servo_pwm_rate = 50;
+  masterConfig.servo_pwm_rate = 50;
 
 #ifdef GPS
-    // gps/nav stuff
-    masterConfig.gpsConfig.provider = GPS_NMEA;
-    masterConfig.gpsConfig.sbasMode = SBAS_AUTO;
-    masterConfig.gpsConfig.autoConfig = GPS_AUTOCONFIG_ON;
-    masterConfig.gpsConfig.autoBaud = GPS_AUTOBAUD_OFF;
+  // gps/nav stuff
+  masterConfig.gpsConfig.provider   = GPS_NMEA;
+  masterConfig.gpsConfig.sbasMode   = SBAS_AUTO;
+  masterConfig.gpsConfig.autoConfig = GPS_AUTOCONFIG_ON;
+  masterConfig.gpsConfig.autoBaud   = GPS_AUTOBAUD_OFF;
 #endif
 
-    resetSerialConfig(&masterConfig.serialConfig);
+  resetSerialConfig ( &masterConfig.serialConfig );
 
-    masterConfig.looptime = 3500;
-    masterConfig.emf_avoidance = 0;
+  masterConfig.looptime      = 3500;
+  masterConfig.emf_avoidance = 0;
 
-    resetPidProfile(&currentProfile->pidProfile);
+  resetPidProfile ( &currentProfile->pidProfile );
 
-    resetControlRateConfig(&masterConfig.controlRateProfiles[0]);
+  resetControlRateConfig ( &masterConfig.controlRateProfiles [ 0 ] );
 
-    // for (i = 0; i < CHECKBOXITEMS; i++)
-    //     cfg.activate[i] = 0;
+  // for (i = 0; i < CHECKBOXITEMS; i++)
+  //     cfg.activate[i] = 0;
 
-    resetRollAndPitchTrims(&currentProfile->accelerometerTrims);
+  resetRollAndPitchTrims ( &currentProfile->accelerometerTrims );
 
-    //Magis aux config
-    modeActivationCondition_t *mac_1 = &currentProfile->modeActivationConditions[0];
-    mac_1->modeId = (boxId_e) 0;    //BOXARM from rccontrols.h
-    mac_1->auxChannelIndex = 3;    //Aux channel 4
-    mac_1->range.startStep = 16;    //Means 1300
-    mac_1->range.endStep = 32;    //Means 1700
+  currentProfile->mag_declination = 0;
+  currentProfile->acc_lpf_factor  = 4;    // krish
+  currentProfile->accz_lpf_cutoff = 5.0f;
+  currentProfile->accDeadband.xy  = 40;
+  currentProfile->accDeadband.z   = 40;
 
-    modeActivationCondition_t *mac_2 = &currentProfile->modeActivationConditions[1];
-    mac_2->modeId = (boxId_e) 1;    //BOXANGLE from rccontrols.h
-    mac_2->auxChannelIndex = 3;    //Aux channel 4
-    mac_2->range.startStep = 0;    //900
-    mac_2->range.endStep = 48;    //2100
+  resetBarometerConfig ( &currentProfile->barometerConfig );
 
-    modeActivationCondition_t *mac_3 = &currentProfile->modeActivationConditions[2];
-    mac_3->modeId = (boxId_e) 3;    //BOXBARO from rccontrols.h
-    mac_3->auxChannelIndex = 2;    //Aux channel 3
-    mac_3->range.startStep = 16;    //1300
-    mac_3->range.endStep = 32;    //1700
+  currentProfile->acc_unarmedcal = 1;
 
-    modeActivationCondition_t *mac_4 = &currentProfile->modeActivationConditions[3];
-    mac_4->modeId = (boxId_e) 4;    //BOXMAG from rccontrols.h
-    mac_4->auxChannelIndex = 0;    //Aux channel 1
-    mac_4->range.startStep = 0;    //900
-    mac_4->range.endStep = 16;    //1300
+  // Radio
+  parseRcChannels ( "AETR1234", &masterConfig.rxConfig );
 
-    modeActivationCondition_t *mac_5 = &currentProfile->modeActivationConditions[4];
-    mac_5->modeId = (boxId_e) 5;    //BOXHEADFREE from rccontrols.h
-    mac_5->auxChannelIndex = 0;    //Aux channel 1
-    mac_5->range.startStep = 16;    //1300
-    mac_5->range.endStep = 32;    //1700
+  resetRcControlsConfig ( &currentProfile->rcControlsConfig );
 
-    currentProfile->mag_declination = 0;
-    currentProfile->acc_lpf_factor = 4;    //krish
-    currentProfile->accz_lpf_cutoff = 5.0f;
-    currentProfile->accDeadband.xy = 40;
-    currentProfile->accDeadband.z = 40;
+  currentProfile->throttle_correction_value = 0;      // could 10 with althold or 40 for fpv
+  currentProfile->throttle_correction_angle = 800;    // could be 80.0 deg with atlhold or 45.0 for fpv
 
-    resetBarometerConfig(&currentProfile->barometerConfig);
-
-    currentProfile->acc_unarmedcal = 1;
-
-    // Radio
-    parseRcChannels("AETR1234", &masterConfig.rxConfig);
-
-    resetRcControlsConfig(&currentProfile->rcControlsConfig);
-
-    currentProfile->throttle_correction_value = 0;      // could 10 with althold or 40 for fpv
-    currentProfile->throttle_correction_angle = 800;    // could be 80.0 deg with atlhold or 45.0 for fpv
-
-    // Failsafe Variables
-    masterConfig.failsafeConfig.failsafe_delay = 10;              // 1sec
-    masterConfig.failsafeConfig.failsafe_off_delay = 200;         // 20sec
-    masterConfig.failsafeConfig.failsafe_throttle = 1300;         // default throttle off. (1000) changed
-    masterConfig.failsafeConfig.failsafe_kill_switch = 0; // default failsafe switch action is identical to rc link loss
-    masterConfig.failsafeConfig.failsafe_throttle_low_delay = 200; // default throttle low delay for "just disarm" on failsafe condition//drona_failsafe default = 100 changed
+  // Failsafe Variables
+  masterConfig.failsafeConfig.failsafe_delay              = 10;      // 1sec
+  masterConfig.failsafeConfig.failsafe_off_delay          = 200;     // 20sec
+  masterConfig.failsafeConfig.failsafe_throttle           = 1300;    // default throttle off. (1000) changed
+  masterConfig.failsafeConfig.failsafe_kill_switch        = 0;       // default failsafe switch action is identical to rc link loss
+  masterConfig.failsafeConfig.failsafe_throttle_low_delay = 200;     // default throttle low delay for "just disarm" on failsafe condition//drona_failsafe default = 100 changed
 
 #ifdef USE_MIXER_SERVOS
-    // servos
-    for (i = 0; i < MAX_SUPPORTED_SERVOS; i++) {
-        currentProfile->servoConf[i].min = DEFAULT_SERVO_MIN;
-        currentProfile->servoConf[i].max = DEFAULT_SERVO_MAX;
-        currentProfile->servoConf[i].middle = DEFAULT_SERVO_MIDDLE;
-        currentProfile->servoConf[i].rate = 100;
-        currentProfile->servoConf[i].angleAtMin = DEFAULT_SERVO_MIN_ANGLE;
-        currentProfile->servoConf[i].angleAtMax = DEFAULT_SERVO_MAX_ANGLE;
-        currentProfile->servoConf[i].forwardFromChannel = CHANNEL_FORWARDING_DISABLED;
-    }
+  // servos
+  for ( i = 0; i < MAX_SUPPORTED_SERVOS; i++ ) {
+    currentProfile->servoConf [ i ].min                = DEFAULT_SERVO_MIN;
+    currentProfile->servoConf [ i ].max                = DEFAULT_SERVO_MAX;
+    currentProfile->servoConf [ i ].middle             = DEFAULT_SERVO_MIDDLE;
+    currentProfile->servoConf [ i ].rate               = 100;
+    currentProfile->servoConf [ i ].angleAtMin         = DEFAULT_SERVO_MIN_ANGLE;
+    currentProfile->servoConf [ i ].angleAtMax         = DEFAULT_SERVO_MAX_ANGLE;
+    currentProfile->servoConf [ i ].forwardFromChannel = CHANNEL_FORWARDING_DISABLED;
+  }
 
-    // gimbal
-    currentProfile->gimbalConfig.mode = GIMBAL_MODE_NORMAL;
+  // gimbal
+  currentProfile->gimbalConfig.mode = GIMBAL_MODE_NORMAL;
 #endif
 
 #ifdef GPS
-    resetGpsProfile(&currentProfile->gpsProfile);
+  resetGpsProfile ( &currentProfile->gpsProfile );
 #endif
 
-    // custom mixer. clear by defaults.
-    for (i = 0; i < MAX_SUPPORTED_MOTORS; i++)
-        masterConfig.customMotorMixer[i].throttle = 0.0f;
+  // custom mixer. clear by defaults.
+  for ( i = 0; i < MAX_SUPPORTED_MOTORS; i++ )
+    masterConfig.customMotorMixer [ i ].throttle = 0.0f;
 
 #ifdef LED_STRIP
-    applyDefaultColors(masterConfig.colors, CONFIGURABLE_COLOR_COUNT);
-    applyDefaultLedStripConfig(masterConfig.ledConfigs);
+  applyDefaultColors ( masterConfig.colors, CONFIGURABLE_COLOR_COUNT );
+  applyDefaultLedStripConfig ( masterConfig.ledConfigs );
 #endif
 
 #ifdef BLACKBOX
-#ifdef SPRACINGF3
-    featureSet(FEATURE_BLACKBOX);
-    masterConfig.blackbox_device = 1;
-#else
-    masterConfig.blackbox_device = 1;
-    featureSet(FEATURE_BLACKBOX);
-#endif
-    masterConfig.blackbox_rate_num = 1;
-    masterConfig.blackbox_rate_denom = 1;
-#endif
-
-    // alternative defaults settings for COLIBRI RACE targets
-#if defined(COLIBRI_RACE)
-    masterConfig.looptime = 1000;
-
-    currentProfile->pidProfile.pidController = 1;
-
-    masterConfig.rxConfig.rcmap[0] = 1;
-    masterConfig.rxConfig.rcmap[1] = 2;
-    masterConfig.rxConfig.rcmap[2] = 3;
-    masterConfig.rxConfig.rcmap[3] = 0;
-    masterConfig.rxConfig.rcmap[4] = 4;
-    masterConfig.rxConfig.rcmap[5] = 5;
-    masterConfig.rxConfig.rcmap[6] = 6;
-    masterConfig.rxConfig.rcmap[7] = 7;
-
-    featureSet(FEATURE_ONESHOT125);
-    featureSet(FEATURE_VBAT);
-    featureSet(FEATURE_LED_STRIP);
-    featureSet(FEATURE_FAILSAFE);
+  #ifdef SPRACINGF3
+  featureSet ( FEATURE_BLACKBOX );
+  masterConfig.blackbox_device = 1;
+  #else
+  masterConfig.blackbox_device = 1;
+  featureSet ( FEATURE_BLACKBOX );
+  #endif
+  masterConfig.blackbox_rate_num   = 1;
+  masterConfig.blackbox_rate_denom = 1;
 #endif
 
-    // alternative defaults settings for ALIENWIIF1 and ALIENWIIF3 targets
+  // alternative defaults settings for COLIBRI RACE targets
+#if defined( COLIBRI_RACE )
+  masterConfig.looptime = 1000;
+
+  currentProfile->pidProfile.pidController = 1;
+
+  masterConfig.rxConfig.rcmap [ 0 ] = 1;
+  masterConfig.rxConfig.rcmap [ 1 ] = 2;
+  masterConfig.rxConfig.rcmap [ 2 ] = 3;
+  masterConfig.rxConfig.rcmap [ 3 ] = 0;
+  masterConfig.rxConfig.rcmap [ 4 ] = 4;
+  masterConfig.rxConfig.rcmap [ 5 ] = 5;
+  masterConfig.rxConfig.rcmap [ 6 ] = 6;
+  masterConfig.rxConfig.rcmap [ 7 ] = 7;
+
+  featureSet ( FEATURE_ONESHOT125 );
+  featureSet ( FEATURE_VBAT );
+  featureSet ( FEATURE_LED_STRIP );
+  featureSet ( FEATURE_FAILSAFE );
+#endif
+
+  // alternative defaults settings for ALIENWIIF1 and ALIENWIIF3 targets
 #ifdef ALIENWII32
-    featureSet(FEATURE_RX_SERIAL);
-    featureSet(FEATURE_MOTOR_STOP);
-    /* #ifdef ALIENWIIF3
-     featureSet(FEATURE_RX_MSP);
+  featureSet ( FEATURE_RX_SERIAL );
+  featureSet ( FEATURE_MOTOR_STOP );
+  /* #ifdef ALIENWIIF3
+   featureSet(FEATURE_RX_MSP);
 
-     //masterConfig.serialConfig.portConfigs[2].functionMask = FUNCTION_RX_SERIAL;
-     //masterConfig.batteryConfig.vbatscale = 20;
-     #else
-     masterConfig.serialConfig.portConfigs[1].functionMask = FUNCTION_RX_SERIAL;
-     #endif */
-    masterConfig.rxConfig.serialrx_provider = 1;
-    masterConfig.rxConfig.spektrum_sat_bind = 5;
-    masterConfig.escAndServoConfig.minthrottle = 1000;
-    masterConfig.escAndServoConfig.maxthrottle = 2000;
-    masterConfig.motor_pwm_rate = 32000;
-    masterConfig.looptime = 3500;
-    currentProfile->pidProfile.pidController = 3;
-    currentProfile->pidProfile.P8[ROLL] = 36;
-    currentProfile->pidProfile.P8[PITCH] = 36;
-    masterConfig.failsafeConfig.failsafe_delay = 2;
-    masterConfig.failsafeConfig.failsafe_off_delay = 0;
-    currentControlRateProfile->rcRate8 = 130;
-    currentControlRateProfile->rates[FD_PITCH] = 20;
-    currentControlRateProfile->rates[FD_ROLL] = 20;
-    currentControlRateProfile->rates[FD_YAW] = 100;
-    parseRcChannels("TAER1234", &masterConfig.rxConfig);
+   //masterConfig.serialConfig.portConfigs[2].functionMask = FUNCTION_RX_SERIAL;
+   //masterConfig.batteryConfig.vbatscale = 20;
+   #else
+   masterConfig.serialConfig.portConfigs[1].functionMask = FUNCTION_RX_SERIAL;
+   #endif */
+  masterConfig.rxConfig.serialrx_provider        = 1;
+  masterConfig.rxConfig.spektrum_sat_bind        = 5;
+  masterConfig.escAndServoConfig.minthrottle     = 1000;
+  masterConfig.escAndServoConfig.maxthrottle     = 2000;
+  masterConfig.motor_pwm_rate                    = 32000;
+  masterConfig.looptime                          = 3500;
+  currentProfile->pidProfile.pidController       = 3;
+  currentProfile->pidProfile.P8 [ ROLL ]         = 36;
+  currentProfile->pidProfile.P8 [ PITCH ]        = 36;
+  masterConfig.failsafeConfig.failsafe_delay     = 2;
+  masterConfig.failsafeConfig.failsafe_off_delay = 0;
+  currentControlRateProfile->rcRate8             = 130;
+  currentControlRateProfile->rates [ FD_PITCH ]  = 20;
+  currentControlRateProfile->rates [ FD_ROLL ]   = 20;
+  currentControlRateProfile->rates [ FD_YAW ]    = 100;
+  parseRcChannels ( "TAER1234", &masterConfig.rxConfig );
 
-    //  { 1.0f, -0.414178f,  1.0f, -1.0f },          // REAR_R
-    masterConfig.customMotorMixer[0].throttle = 1.0f;
-    masterConfig.customMotorMixer[0].roll = -0.414178f;
-    masterConfig.customMotorMixer[0].pitch = 1.0f;
-    masterConfig.customMotorMixer[0].yaw = -1.0f;
+  //  { 1.0f, -0.414178f,  1.0f, -1.0f },          // REAR_R
+  masterConfig.customMotorMixer [ 0 ].throttle = 1.0f;
+  masterConfig.customMotorMixer [ 0 ].roll     = -0.414178f;
+  masterConfig.customMotorMixer [ 0 ].pitch    = 1.0f;
+  masterConfig.customMotorMixer [ 0 ].yaw      = -1.0f;
 
-    //  { 1.0f, -0.414178f, -1.0f,  1.0f },          // FRONT_R
-    masterConfig.customMotorMixer[1].throttle = 1.0f;
-    masterConfig.customMotorMixer[1].roll = -0.414178f;
-    masterConfig.customMotorMixer[1].pitch = -1.0f;
-    masterConfig.customMotorMixer[1].yaw = 1.0f;
+  //  { 1.0f, -0.414178f, -1.0f,  1.0f },          // FRONT_R
+  masterConfig.customMotorMixer [ 1 ].throttle = 1.0f;
+  masterConfig.customMotorMixer [ 1 ].roll     = -0.414178f;
+  masterConfig.customMotorMixer [ 1 ].pitch    = -1.0f;
+  masterConfig.customMotorMixer [ 1 ].yaw      = 1.0f;
 
-    //  { 1.0f,  0.414178f,  1.0f,  1.0f },          // REAR_L
-    masterConfig.customMotorMixer[2].throttle = 1.0f;
-    masterConfig.customMotorMixer[2].roll = 0.414178f;
-    masterConfig.customMotorMixer[2].pitch = 1.0f;
-    masterConfig.customMotorMixer[2].yaw = 1.0f;
+  //  { 1.0f,  0.414178f,  1.0f,  1.0f },          // REAR_L
+  masterConfig.customMotorMixer [ 2 ].throttle = 1.0f;
+  masterConfig.customMotorMixer [ 2 ].roll     = 0.414178f;
+  masterConfig.customMotorMixer [ 2 ].pitch    = 1.0f;
+  masterConfig.customMotorMixer [ 2 ].yaw      = 1.0f;
 
-    //  { 1.0f,  0.414178f, -1.0f, -1.0f },          // FRONT_L
-    masterConfig.customMotorMixer[3].throttle = 1.0f;
-    masterConfig.customMotorMixer[3].roll = 0.414178f;
-    masterConfig.customMotorMixer[3].pitch = -1.0f;
-    masterConfig.customMotorMixer[3].yaw = -1.0f;
+  //  { 1.0f,  0.414178f, -1.0f, -1.0f },          // FRONT_L
+  masterConfig.customMotorMixer [ 3 ].throttle = 1.0f;
+  masterConfig.customMotorMixer [ 3 ].roll     = 0.414178f;
+  masterConfig.customMotorMixer [ 3 ].pitch    = -1.0f;
+  masterConfig.customMotorMixer [ 3 ].yaw      = -1.0f;
 
-    //  { 1.0f, -1.0f, -0.414178f, -1.0f },          // MIDFRONT_R
-    masterConfig.customMotorMixer[4].throttle = 1.0f;
-    masterConfig.customMotorMixer[4].roll = -1.0f;
-    masterConfig.customMotorMixer[4].pitch = -0.414178f;
-    masterConfig.customMotorMixer[4].yaw = -1.0f;
+  //  { 1.0f, -1.0f, -0.414178f, -1.0f },          // MIDFRONT_R
+  masterConfig.customMotorMixer [ 4 ].throttle = 1.0f;
+  masterConfig.customMotorMixer [ 4 ].roll     = -1.0f;
+  masterConfig.customMotorMixer [ 4 ].pitch    = -0.414178f;
+  masterConfig.customMotorMixer [ 4 ].yaw      = -1.0f;
 
-    //  { 1.0f,  1.0f, -0.414178f,  1.0f },          // MIDFRONT_L
-    masterConfig.customMotorMixer[5].throttle = 1.0f;
-    masterConfig.customMotorMixer[5].roll = 1.0f;
-    masterConfig.customMotorMixer[5].pitch = -0.414178f;
-    masterConfig.customMotorMixer[5].yaw = 1.0f;
+  //  { 1.0f,  1.0f, -0.414178f,  1.0f },          // MIDFRONT_L
+  masterConfig.customMotorMixer [ 5 ].throttle = 1.0f;
+  masterConfig.customMotorMixer [ 5 ].roll     = 1.0f;
+  masterConfig.customMotorMixer [ 5 ].pitch    = -0.414178f;
+  masterConfig.customMotorMixer [ 5 ].yaw      = 1.0f;
 
-    //  { 1.0f, -1.0f,  0.414178f,  1.0f },          // MIDREAR_R
-    masterConfig.customMotorMixer[6].throttle = 1.0f;
-    masterConfig.customMotorMixer[6].roll = -1.0f;
-    masterConfig.customMotorMixer[6].pitch = 0.414178f;
-    masterConfig.customMotorMixer[6].yaw = 1.0f;
+  //  { 1.0f, -1.0f,  0.414178f,  1.0f },          // MIDREAR_R
+  masterConfig.customMotorMixer [ 6 ].throttle = 1.0f;
+  masterConfig.customMotorMixer [ 6 ].roll     = -1.0f;
+  masterConfig.customMotorMixer [ 6 ].pitch    = 0.414178f;
+  masterConfig.customMotorMixer [ 6 ].yaw      = 1.0f;
 
-    //  { 1.0f,  1.0f,  0.414178f, -1.0f },          // MIDREAR_L
-    masterConfig.customMotorMixer[7].throttle = 1.0f;
-    masterConfig.customMotorMixer[7].roll = 1.0f;
-    masterConfig.customMotorMixer[7].pitch = 0.414178f;
-    masterConfig.customMotorMixer[7].yaw = -1.0f;
+  //  { 1.0f,  1.0f,  0.414178f, -1.0f },          // MIDREAR_L
+  masterConfig.customMotorMixer [ 7 ].throttle = 1.0f;
+  masterConfig.customMotorMixer [ 7 ].roll     = 1.0f;
+  masterConfig.customMotorMixer [ 7 ].pitch    = 0.414178f;
+  masterConfig.customMotorMixer [ 7 ].yaw      = -1.0f;
 #endif
 
-    // copy first profile into remaining profile
-    for (i = 1; i < MAX_PROFILE_COUNT; i++) {
-        memcpy(&masterConfig.profile[i], currentProfile, sizeof(profile_t));
-    }
+  // copy first profile into remaining profile
+  for ( i = 1; i < MAX_PROFILE_COUNT; i++ ) {
+    memcpy ( &masterConfig.profile [ i ], currentProfile, sizeof ( profile_t ) );
+  }
 
-    // copy first control rate config into remaining profile
-    for (i = 1; i < MAX_CONTROL_RATE_PROFILE_COUNT; i++) {
-        memcpy(&masterConfig.controlRateProfiles[i], currentControlRateProfile, sizeof(controlRateConfig_t));
-    }
+  // copy first control rate config into remaining profile
+  for ( i = 1; i < MAX_CONTROL_RATE_PROFILE_COUNT; i++ ) {
+    memcpy ( &masterConfig.controlRateProfiles [ i ], currentControlRateProfile, sizeof ( controlRateConfig_t ) );
+  }
 
-    for (i = 1; i < MAX_PROFILE_COUNT; i++) {
-        masterConfig.profile[i].defaultRateProfileIndex = i % MAX_CONTROL_RATE_PROFILE_COUNT;
-    }
+  for ( i = 1; i < MAX_PROFILE_COUNT; i++ ) {
+    masterConfig.profile [ i ].defaultRateProfileIndex = i % MAX_CONTROL_RATE_PROFILE_COUNT;
+  }
 }
 
-static uint8_t calculateChecksum(const uint8_t *data, uint32_t length)
-{
-    uint8_t checksum = 0;
-    const uint8_t *byteOffset;
+static uint8_t calculateChecksum ( const uint8_t *data, uint32_t length ) {
+  uint8_t checksum = 0;
+  const uint8_t *byteOffset;
 
-    for (byteOffset = data; byteOffset < (data + length); byteOffset++)
-        checksum ^= *byteOffset;
-    return checksum;
+  for ( byteOffset = data; byteOffset < ( data + length ); byteOffset++ )
+    checksum ^= *byteOffset;
+  return checksum;
 }
 
-static bool isEEPROMContentValid(void)
-{
-    const master_t *temp = (const master_t *) CONFIG_START_FLASH_ADDRESS;
-    uint8_t checksum = 0;
+static bool isEEPROMContentValid ( void ) {
+  const master_t *temp = ( const master_t * ) CONFIG_START_FLASH_ADDRESS;
+  uint8_t checksum     = 0;
 
-    // check version number
-    if (EEPROM_CONF_VERSION != temp->version)
-        return false;
+  // check version number
+  if ( EEPROM_CONF_VERSION != temp->version )
+    return false;
 
-    // check size and magic numbers
-    if (temp->size != sizeof(master_t) || temp->magic_be != 0xBE || temp->magic_ef != 0xEF)
-        return false;
+  // check size and magic numbers
+  if ( temp->size != sizeof ( master_t ) || temp->magic_be != 0xBE || temp->magic_ef != 0xEF )
+    return false;
 
-    // verify integrity of temporary copy
-    checksum = calculateChecksum((const uint8_t *) temp, sizeof(master_t));
-    if (checksum != 0)
-        return false;
+  // verify integrity of temporary copy
+  checksum = calculateChecksum ( ( const uint8_t * ) temp, sizeof ( master_t ) );
+  if ( checksum != 0 )
+    return false;
 
-    // looks good, let's roll!
-    return true;
+  // looks good, let's roll!
+  return true;
 }
 
-void activateControlRateConfig(void)
-{
-    generatePitchRollCurve(currentControlRateProfile);
-    generateYawCurve(currentControlRateProfile);
-    generateThrottleCurve(currentControlRateProfile, &masterConfig.escAndServoConfig);
+void activateControlRateConfig ( void ) {
+  generatePitchRollCurve ( currentControlRateProfile );
+  generateYawCurve ( currentControlRateProfile );
+  generateThrottleCurve ( currentControlRateProfile, &masterConfig.escAndServoConfig );
 }
 
-void activateConfig(void)
-{
-    static imuRuntimeConfig_t imuRuntimeConfig;
+void activateConfig ( void ) {
+  static imuRuntimeConfig_t imuRuntimeConfig;
 
-    activateControlRateConfig();
+  activateControlRateConfig ( );
 
-    resetAdjustmentStates();
+  resetAdjustmentStates ( );
 
-    useRcControlsConfig(currentProfile->modeActivationConditions, &masterConfig.escAndServoConfig, &currentProfile->pidProfile);
+  useRcControlsConfig ( currentProfile->modeActivationConditions, &masterConfig.escAndServoConfig, &currentProfile->pidProfile );
 
-    useGyroConfig(&masterConfig.gyroConfig);
+  useGyroConfig ( &masterConfig.gyroConfig );
 
 #ifdef TELEMETRY
-    telemetryUseConfig(&masterConfig.telemetryConfig);
+  telemetryUseConfig ( &masterConfig.telemetryConfig );
 #endif
 
-    pidSetController((pidControllerType_e) currentProfile->pidProfile.pidController);
+  pidSetController ( ( pidControllerType_e ) currentProfile->pidProfile.pidController );
 
 #ifdef GPS
-    gpsUseProfile(&currentProfile->gpsProfile);
-    gpsUsePIDs(&currentProfile->pidProfile);
+  gpsUseProfile ( &currentProfile->gpsProfile );
+  gpsUsePIDs ( &currentProfile->pidProfile );
 #endif
 
-    useFailsafeConfig(&masterConfig.failsafeConfig);
-    setAccelerationTrims(&masterConfig.accZero);
-    setAccelerationCalibration(&masterConfig.accCalData);
+  useFailsafeConfig ( &masterConfig.failsafeConfig );
+  setAccelerationTrims ( &masterConfig.accZero );
+  setAccelerationCalibration ( &masterConfig.accCalData );
 
-    mixerUseConfigs(
+  mixerUseConfigs (
 #ifdef USE_MIXER_SERVOS
             currentProfile->servoConf, &currentProfile->gimbalConfig,
 #endif
-            &masterConfig.flight3DConfig, &masterConfig.escAndServoConfig, &masterConfig.mixerConfig, &masterConfig.airplaneConfig, &masterConfig.rxConfig);
+            &masterConfig.flight3DConfig, &masterConfig.escAndServoConfig, &masterConfig.mixerConfig, &masterConfig.airplaneConfig, &masterConfig.rxConfig );
 
-    imuRuntimeConfig.gyro_cmpf_factor = masterConfig.gyro_cmpf_factor;
-    imuRuntimeConfig.gyro_cmpfm_factor = masterConfig.gyro_cmpfm_factor;
-    imuRuntimeConfig.acc_lpf_factor = currentProfile->acc_lpf_factor;
-    imuRuntimeConfig.acc_unarmedcal = currentProfile->acc_unarmedcal;
-    ;
-    imuRuntimeConfig.small_angle = masterConfig.small_angle;
+  imuRuntimeConfig.gyro_cmpf_factor  = masterConfig.gyro_cmpf_factor;
+  imuRuntimeConfig.gyro_cmpfm_factor = masterConfig.gyro_cmpfm_factor;
+  imuRuntimeConfig.acc_lpf_factor    = currentProfile->acc_lpf_factor;
+  imuRuntimeConfig.acc_unarmedcal    = currentProfile->acc_unarmedcal;
+  ;
+  imuRuntimeConfig.small_angle = masterConfig.small_angle;
 
-    imuConfigure(&imuRuntimeConfig, &currentProfile->pidProfile, &currentProfile->accDeadband, currentProfile->accz_lpf_cutoff, currentProfile->throttle_correction_angle);
+  imuConfigure ( &imuRuntimeConfig, &currentProfile->pidProfile, &currentProfile->accDeadband, currentProfile->accz_lpf_cutoff, currentProfile->throttle_correction_angle );
 
-    configureAltitudeHold(&currentProfile->pidProfile, &currentProfile->barometerConfig, &currentProfile->rcControlsConfig, &masterConfig.escAndServoConfig);
+  configureAltitudeHold ( &currentProfile->pidProfile, &currentProfile->barometerConfig, &currentProfile->rcControlsConfig, &masterConfig.escAndServoConfig );
 
-    configurePosHold(&currentProfile->pidProfile, &currentProfile->rcControlsConfig); //PS2
-    configurePosHold2(&currentProfile->pidProfile); //PS2
+  configurePosHold ( &currentProfile->pidProfile, &currentProfile->rcControlsConfig );    // PS2
+  configurePosHold2 ( &currentProfile->pidProfile );                                      // PS2
 
 #ifdef BARO
-    useBarometerConfig(&currentProfile->barometerConfig);
+  useBarometerConfig ( &currentProfile->barometerConfig );
 #endif
 }
 
-void validateAndFixConfig(void)
-{
-    if (!(featureConfigured(FEATURE_RX_PARALLEL_PWM) || featureConfigured(FEATURE_RX_PPM) || featureConfigured(FEATURE_RX_SERIAL) || featureConfigured(FEATURE_RX_MSP))) {
-        featureSet(FEATURE_RX_PARALLEL_PWM); // Consider changing the default to PPM
-    }
+void validateAndFixConfig ( void ) {
 
-    if (featureConfigured(FEATURE_RX_PPM)) {
-        featureClear(FEATURE_RX_PARALLEL_PWM);
-    }
 
-    if (featureConfigured(FEATURE_RX_MSP)) {
-        featureClear(FEATURE_RX_SERIAL);
-        featureClear(FEATURE_RX_PARALLEL_PWM);
-        featureClear(FEATURE_RX_PPM);
-        //       featureSet(FEATURE_RX_PARALLEL_PWM);
-        //       featureSet(FEATURE_RX_PPM);
-    }
+  plutoRxConfig ( );
 
-    if (featureConfigured(FEATURE_RX_SERIAL)) {
-        featureClear(FEATURE_RX_PARALLEL_PWM);
-        featureClear(FEATURE_RX_PPM);
-    }
 
-    if (featureConfigured(FEATURE_RX_PARALLEL_PWM)) {
-#if defined(STM32F10X)
-        // rssi adc needs the same ports
-        featureClear(FEATURE_RSSI_ADC);
-        // current meter needs the same ports
-        if (masterConfig.batteryConfig.currentMeterType == CURRENT_SENSOR_ADC) {
-            featureClear(FEATURE_CURRENT_METER);
-        }
-#endif
 
-#if defined(STM32F10X) || defined(CHEBUZZ) || defined(STM32F3DISCOVERY)
-        // led strip needs the same ports
-        featureClear(FEATURE_LED_STRIP);
-#endif
+  if ( ! ( featureConfigured ( FEATURE_RX_PARALLEL_PWM ) || featureConfigured ( FEATURE_RX_PPM ) || featureConfigured ( FEATURE_RX_SERIAL ) || featureConfigured ( FEATURE_RX_MSP ) ) ) {
+    featureSet ( FEATURE_RX_PARALLEL_PWM );    // Consider changing the default to PPM
+  }
 
-        // software serial needs free PWM ports
-        featureClear(FEATURE_SOFTSERIAL);
-    }
+  if ( featureConfigured ( FEATURE_RX_PPM ) ) {
+    featureClear ( FEATURE_RX_PARALLEL_PWM );
+  }
 
-#if defined(LED_STRIP) && (defined(USE_SOFTSERIAL1) || defined(USE_SOFTSERIAL2))
-    if (featureConfigured(FEATURE_SOFTSERIAL) && (0
-#ifdef USE_SOFTSERIAL1
-            || (LED_STRIP_TIMER == SOFTSERIAL_1_TIMER)
-#endif
-#ifdef USE_SOFTSERIAL2
-            || (LED_STRIP_TIMER == SOFTSERIAL_2_TIMER)
-#endif
-            )) {
-        // led strip needs the same timer as softserial
-        featureClear(FEATURE_LED_STRIP);
+  if ( featureConfigured ( FEATURE_RX_MSP ) ) {
+    featureClear ( FEATURE_RX_SERIAL );
+    featureClear ( FEATURE_RX_PARALLEL_PWM );
+    featureClear ( FEATURE_RX_PPM );
+    //       featureSet(FEATURE_RX_PARALLEL_PWM);
+    //       featureSet(FEATURE_RX_PPM);
+  }
+
+  if ( featureConfigured ( FEATURE_RX_SERIAL ) ) {
+    featureClear ( FEATURE_RX_PARALLEL_PWM );
+    featureClear ( FEATURE_RX_PPM );
+  }
+
+
+
+  if ( featureConfigured ( FEATURE_RX_PARALLEL_PWM ) ) {
+#if defined( STM32F10X )
+    // rssi adc needs the same ports
+    featureClear ( FEATURE_RSSI_ADC );
+    // current meter needs the same ports
+    if ( masterConfig.batteryConfig.currentMeterType == CURRENT_SENSOR_ADC ) {
+      featureClear ( FEATURE_CURRENT_METER );
     }
 #endif
 
-#if defined(NAZE) && defined(SONAR)
-    if (featureConfigured(FEATURE_RX_PARALLEL_PWM) && featureConfigured(FEATURE_SONAR) && featureConfigured(FEATURE_CURRENT_METER) && masterConfig.batteryConfig.currentMeterType == CURRENT_SENSOR_ADC) {
-        featureClear(FEATURE_CURRENT_METER);
-    }
+#if defined( STM32F10X ) || defined( CHEBUZZ ) || defined( STM32F3DISCOVERY )
+    // led strip needs the same ports
+    featureClear ( FEATURE_LED_STRIP );
 #endif
 
-#if defined(OLIMEXINO) && defined(SONAR)
-    if (feature(FEATURE_SONAR) && feature(FEATURE_CURRENT_METER) && masterConfig.batteryConfig.currentMeterType == CURRENT_SENSOR_ADC) {
-        featureClear(FEATURE_CURRENT_METER);
-    }
+    // software serial needs free PWM ports
+    featureClear ( FEATURE_SOFTSERIAL );
+  }
+
+#if defined( LED_STRIP ) && ( defined( USE_SOFTSERIAL1 ) || defined( USE_SOFTSERIAL2 ) )
+  if ( featureConfigured ( FEATURE_SOFTSERIAL ) && ( 0
+  #ifdef USE_SOFTSERIAL1
+                                                     || ( LED_STRIP_TIMER == SOFTSERIAL_1_TIMER )
+  #endif
+  #ifdef USE_SOFTSERIAL2
+                                                     || ( LED_STRIP_TIMER == SOFTSERIAL_2_TIMER )
+  #endif
+                                                               ) ) {
+    // led strip needs the same timer as softserial
+    featureClear ( FEATURE_LED_STRIP );
+  }
 #endif
 
-#if defined(CC3D) && defined(DISPLAY) && defined(USE_USART3)
-    if (doesConfigurationUsePort(SERIAL_PORT_USART3) && feature(FEATURE_DISPLAY)) {
-        featureClear(FEATURE_DISPLAY);
-    }
+#if defined( NAZE ) && defined( SONAR )
+  if ( featureConfigured ( FEATURE_RX_PARALLEL_PWM ) && featureConfigured ( FEATURE_SONAR ) && featureConfigured ( FEATURE_CURRENT_METER ) && masterConfig.batteryConfig.currentMeterType == CURRENT_SENSOR_ADC ) {
+    featureClear ( FEATURE_CURRENT_METER );
+  }
+#endif
+
+#if defined( OLIMEXINO ) && defined( SONAR )
+  if ( feature ( FEATURE_SONAR ) && feature ( FEATURE_CURRENT_METER ) && masterConfig.batteryConfig.currentMeterType == CURRENT_SENSOR_ADC ) {
+    featureClear ( FEATURE_CURRENT_METER );
+  }
+#endif
+
+#if defined( CC3D ) && defined( DISPLAY ) && defined( USE_USART3 )
+  if ( doesConfigurationUsePort ( SERIAL_PORT_USART3 ) && feature ( FEATURE_DISPLAY ) ) {
+    featureClear ( FEATURE_DISPLAY );
+  }
 #endif
 
 #ifdef STM32F303xC
-    // hardware supports serial port inversion, make users life easier for those that want to connect SBus RX's
-    masterConfig.telemetryConfig.telemetry_inversion = 1;
+  // hardware supports serial port inversion, make users life easier for those that want to connect SBus RX's
+  masterConfig.telemetryConfig.telemetry_inversion = 1;
 #endif
 
-    /*
-     * The retarded_arm setting is incompatible with pid_at_min_throttle because full roll causes the craft to roll over on the ground.
-     * The pid_at_min_throttle implementation ignores yaw on the ground, but doesn't currently ignore roll when retarded_arm is enabled.
-     */
-    if (masterConfig.retarded_arm && masterConfig.mixerConfig.pid_at_min_throttle) {
-        masterConfig.mixerConfig.pid_at_min_throttle = 0;
-    }
+  /*
+   * The retarded_arm setting is incompatible with pid_at_min_throttle because full roll causes the craft to roll over on the ground.
+   * The pid_at_min_throttle implementation ignores yaw on the ground, but doesn't currently ignore roll when retarded_arm is enabled.
+   */
+  if ( masterConfig.retarded_arm && masterConfig.mixerConfig.pid_at_min_throttle ) {
+    masterConfig.mixerConfig.pid_at_min_throttle = 0;
+  }
 
-#if defined(CC3D) && defined(SONAR) && defined(USE_SOFTSERIAL1)
-    if (feature(FEATURE_SONAR) && feature(FEATURE_SOFTSERIAL)) {
-        featureClear(FEATURE_SONAR);
-    }
+#if defined( CC3D ) && defined( SONAR ) && defined( USE_SOFTSERIAL1 )
+  if ( feature ( FEATURE_SONAR ) && feature ( FEATURE_SOFTSERIAL ) ) {
+    featureClear ( FEATURE_SONAR );
+  }
 #endif
 
-#if defined(COLIBRI_RACE)
-    masterConfig.serialConfig.portConfigs[0].functionMask = FUNCTION_MSP;
-    if(featureConfigured(FEATURE_RX_SERIAL)) {
-        masterConfig.serialConfig.portConfigs[2].functionMask = FUNCTION_RX_SERIAL;
-    }
+#if defined( COLIBRI_RACE )
+  masterConfig.serialConfig.portConfigs [ 0 ].functionMask = FUNCTION_MSP;
+  if ( featureConfigured ( FEATURE_RX_SERIAL ) ) {
+    masterConfig.serialConfig.portConfigs [ 2 ].functionMask = FUNCTION_RX_SERIAL;
+  }
 #endif
 
-    useRxConfig(&masterConfig.rxConfig);
+  useRxConfig ( &masterConfig.rxConfig );
 
-    serialConfig_t *serialConfig = &masterConfig.serialConfig;
+  serialConfig_t *serialConfig = &masterConfig.serialConfig;
 
-    if (!isSerialConfigValid(serialConfig)) {
-        resetSerialConfig(serialConfig);
-    }
+  if ( ! isSerialConfigValid ( serialConfig ) ) {
+    resetSerialConfig ( serialConfig );
+  }
 }
 
-void initEEPROM(void)
-{
+void initEEPROM ( void ) {
 }
 
-void readEEPROM(void)
-{
-    // Sanity check
-    if (!isEEPROMContentValid())
-        failureMode(FAILURE_INVALID_EEPROM_CONTENTS);
+void readEEPROM ( void ) {
+  // Sanity check
+  if ( ! isEEPROMContentValid ( ) )
+    failureMode ( FAILURE_INVALID_EEPROM_CONTENTS );
 
-    suspendRxSignal();
+  suspendRxSignal ( );
 
-    // Read flash
-    memcpy(&masterConfig, (char *) CONFIG_START_FLASH_ADDRESS, sizeof(master_t));
+  // Read flash
+  memcpy ( &masterConfig, ( char * ) CONFIG_START_FLASH_ADDRESS, sizeof ( master_t ) );
 
-    if (masterConfig.current_profile_index > MAX_PROFILE_COUNT - 1) // sanity check
-        masterConfig.current_profile_index = 0;
+  if ( masterConfig.current_profile_index > MAX_PROFILE_COUNT - 1 )    // sanity check
+    masterConfig.current_profile_index = 0;
 
-    setProfile(masterConfig.current_profile_index);
+  setProfile ( masterConfig.current_profile_index );
 
-    if (currentProfile->defaultRateProfileIndex > MAX_CONTROL_RATE_PROFILE_COUNT - 1) // sanity check
-        currentProfile->defaultRateProfileIndex = 0;
+  if ( currentProfile->defaultRateProfileIndex > MAX_CONTROL_RATE_PROFILE_COUNT - 1 )    // sanity check
+    currentProfile->defaultRateProfileIndex = 0;
 
-    setControlRateProfile(currentProfile->defaultRateProfileIndex);
+  setControlRateProfile ( currentProfile->defaultRateProfileIndex );
 
-    validateAndFixConfig();
-    activateConfig();
+  validateAndFixConfig ( );
+  activateConfig ( );
 
-    resumeRxSignal();
+  resumeRxSignal ( );
 }
 
-void readEEPROMAndNotify(void)
-{
-    // re-read written data
-    readEEPROM();
-    beeperConfirmationBeeps(1);
+void readEEPROMAndNotify ( void ) {
+  // re-read written data
+  readEEPROM ( );
+  beeperConfirmationBeeps ( 1 );
 }
 
-void writeEEPROM(void)
-{
-    // Generate compile time error if the config does not fit in the reserved area of flash.
-    BUILD_BUG_ON(sizeof(master_t) > FLASH_TO_RESERVE_FOR_CONFIG);
+void writeEEPROM ( void ) {
+  // Generate compile time error if the config does not fit in the reserved area of flash.
+  BUILD_BUG_ON ( sizeof ( master_t ) > FLASH_TO_RESERVE_FOR_CONFIG );
 
-    FLASH_Status status = (FLASH_Status) 0;
-    uint32_t wordOffset;
-    int8_t attemptsRemaining = 3;
+  FLASH_Status status = ( FLASH_Status ) 0;
+  uint32_t wordOffset;
+  int8_t attemptsRemaining = 3;
 
-    suspendRxSignal();
+  suspendRxSignal ( );
 
-    // prepare checksum/version constants
-    masterConfig.version = EEPROM_CONF_VERSION;
-    masterConfig.size = sizeof(master_t);
-    masterConfig.magic_be = 0xBE;
-    masterConfig.magic_ef = 0xEF;
-    masterConfig.chk = 0; // erase checksum before recalculating
-    masterConfig.chk = calculateChecksum((const uint8_t *) &masterConfig, sizeof(master_t));
+  // prepare checksum/version constants
+  masterConfig.version  = EEPROM_CONF_VERSION;
+  masterConfig.size     = sizeof ( master_t );
+  masterConfig.magic_be = 0xBE;
+  masterConfig.magic_ef = 0xEF;
+  masterConfig.chk      = 0;    // erase checksum before recalculating
+  masterConfig.chk      = calculateChecksum ( ( const uint8_t * ) &masterConfig, sizeof ( master_t ) );
 
-    // write it
-    FLASH_Unlock();
-    while (attemptsRemaining--) {
+  // write it
+  FLASH_Unlock ( );
+  while ( attemptsRemaining-- ) {
 #ifdef STM32F303
-        FLASH_ClearFlag(FLASH_FLAG_EOP | FLASH_FLAG_PGERR | FLASH_FLAG_WRPERR);
+    FLASH_ClearFlag ( FLASH_FLAG_EOP | FLASH_FLAG_PGERR | FLASH_FLAG_WRPERR );
 #endif
 #ifdef STM32F10X
-        FLASH_ClearFlag(FLASH_FLAG_EOP | FLASH_FLAG_PGERR | FLASH_FLAG_WRPRTERR);
+    FLASH_ClearFlag ( FLASH_FLAG_EOP | FLASH_FLAG_PGERR | FLASH_FLAG_WRPRTERR );
 #endif
-        for (wordOffset = 0; wordOffset < sizeof(master_t); wordOffset += 4) {
-            if (wordOffset % FLASH_PAGE_SIZE == 0) {
-                status = FLASH_ErasePage(CONFIG_START_FLASH_ADDRESS + wordOffset);
-                if (status != FLASH_COMPLETE) {
-                    break;
-                }
-            }
-
-            status = FLASH_ProgramWord(CONFIG_START_FLASH_ADDRESS + wordOffset, *(uint32_t *) ((char *) &masterConfig + wordOffset));
-            if (status != FLASH_COMPLETE) {
-                break;
-            }
+    for ( wordOffset = 0; wordOffset < sizeof ( master_t ); wordOffset += 4 ) {
+      if ( wordOffset % FLASH_PAGE_SIZE == 0 ) {
+        status = FLASH_ErasePage ( CONFIG_START_FLASH_ADDRESS + wordOffset );
+        if ( status != FLASH_COMPLETE ) {
+          break;
         }
-        if (status == FLASH_COMPLETE) {
-            break;
-        }
+      }
+
+      status = FLASH_ProgramWord ( CONFIG_START_FLASH_ADDRESS + wordOffset, *( uint32_t * ) ( ( char * ) &masterConfig + wordOffset ) );
+      if ( status != FLASH_COMPLETE ) {
+        break;
+      }
     }
-    FLASH_Lock();
-
-    // Flash write failed - just die now
-    if (status != FLASH_COMPLETE || !isEEPROMContentValid()) {
-        failureMode(FAILURE_FLASH_WRITE_FAILED);
+    if ( status == FLASH_COMPLETE ) {
+      break;
     }
+  }
+  FLASH_Lock ( );
 
-    resumeRxSignal();
+  // Flash write failed - just die now
+  if ( status != FLASH_COMPLETE || ! isEEPROMContentValid ( ) ) {
+    failureMode ( FAILURE_FLASH_WRITE_FAILED );
+  }
+
+  resumeRxSignal ( );
 }
 
-void ensureEEPROMContainsValidData(void)
-{
-    if (isEEPROMContentValid()) {
-        return;
-    }
+void ensureEEPROMContainsValidData ( void ) {
+  if ( isEEPROMContentValid ( ) ) {
+    return;
+  }
 
-    resetEEPROM();
+  resetEEPROM ( );
 }
 
-void resetEEPROM(void)
-{
-    resetConf();
-    writeEEPROM();
+void resetEEPROM ( void ) {
+  resetConf ( );
+  writeEEPROM ( );
 }
 
-void saveConfigAndNotify(void)
-{
-    writeEEPROM();
-    readEEPROMAndNotify();
+void saveConfigAndNotify ( void ) {
+  writeEEPROM ( );
+  readEEPROMAndNotify ( );
 }
 
-void changeProfile(uint8_t profileIndex)
-{
-    masterConfig.current_profile_index = profileIndex;
-    writeEEPROM();
-    readEEPROM();
-    beeperConfirmationBeeps(profileIndex + 1);
+void changeProfile ( uint8_t profileIndex ) {
+  masterConfig.current_profile_index = profileIndex;
+  writeEEPROM ( );
+  readEEPROM ( );
+  beeperConfirmationBeeps ( profileIndex + 1 );
 }
 
-void changeControlRateProfile(uint8_t profileIndex)
-{
-    if (profileIndex > MAX_CONTROL_RATE_PROFILE_COUNT) {
-        profileIndex = MAX_CONTROL_RATE_PROFILE_COUNT - 1;
-    }
-    setControlRateProfile(profileIndex);
-    activateControlRateConfig();
+void changeControlRateProfile ( uint8_t profileIndex ) {
+  if ( profileIndex > MAX_CONTROL_RATE_PROFILE_COUNT ) {
+    profileIndex = MAX_CONTROL_RATE_PROFILE_COUNT - 1;
+  }
+  setControlRateProfile ( profileIndex );
+  activateControlRateConfig ( );
 }
 
-void handleOneshotFeatureChangeOnRestart(void)
-{
-    // Shutdown PWM on all motors prior to soft restart
-    StopPwmAllMotors();
-    delay(50);
-    // Apply additional delay when OneShot125 feature changed from on to off state
-    if (feature(FEATURE_ONESHOT125) && !featureConfigured(FEATURE_ONESHOT125)) {
-        delay(ONESHOT_FEATURE_CHANGED_DELAY_ON_BOOT_MS);
-    }
+void handleOneshotFeatureChangeOnRestart ( void ) {
+  // Shutdown PWM on all motors prior to soft restart
+  StopPwmAllMotors ( );
+  delay ( 50 );
+  // Apply additional delay when OneShot125 feature changed from on to off state
+  if ( feature ( FEATURE_ONESHOT125 ) && ! featureConfigured ( FEATURE_ONESHOT125 ) ) {
+    delay ( ONESHOT_FEATURE_CHANGED_DELAY_ON_BOOT_MS );
+  }
 }
 
-void latchActiveFeatures()
-{
-    activeFeaturesLatch = masterConfig.enabledFeatures;
+void latchActiveFeatures ( ) {
+  activeFeaturesLatch = masterConfig.enabledFeatures;
 }
 
-bool featureConfigured(uint32_t mask)
-{
-    return masterConfig.enabledFeatures & mask;
+bool featureConfigured ( uint32_t mask ) {
+  return masterConfig.enabledFeatures & mask;
 }
 
-bool feature(uint32_t mask)
-{
-    return activeFeaturesLatch & mask;
+bool feature ( uint32_t mask ) {
+  return activeFeaturesLatch & mask;
 }
 
-void featureSet(uint32_t mask)
-{
-    masterConfig.enabledFeatures |= mask;
+void featureSet ( uint32_t mask ) {
+  masterConfig.enabledFeatures |= mask;
 }
 
-void featureClear(uint32_t mask)
-{
-    masterConfig.enabledFeatures &= ~(mask);
+void featureClear ( uint32_t mask ) {
+  masterConfig.enabledFeatures &= ~( mask );
 }
 
-void featureClearAll()
-{
-    masterConfig.enabledFeatures = 0;
+void featureClearAll ( ) {
+  masterConfig.enabledFeatures = 0;
 }
 
-uint32_t featureMask(void)
-{
-    return masterConfig.enabledFeatures;
+uint32_t featureMask ( void ) {
+  return masterConfig.enabledFeatures;
 }
-


### PR DESCRIPTION
Introduced a new module to configure receiver modes, supporting both PPM and ESP setups. This change includes the addition of `RxConfig.cpp` and `RxConfig.h` files, which define the logic for setting up auxiliary channels and configuring receiver modes. The `Makefile` has been updated to include the new source file. Additionally, the `PlutoPilot` API has been expanded with a function to initialize the receiver configuration. These enhancements aim to improve flexibility in handling different receiver configurations.

Manual for Rc_Rx_Config_P API Usage
Public Functions:
void rxMode(rx_mode_e rxMode): Configure the receiver mode (Rx_ESP or Rx_PPM). void configureArmMode(rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange): Configure the ARM mode with specified RX channel and range. void configureModeANGLE(rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange): Configure the ANGLE mode similarly. void configureModeBARO(rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange): Configure the BARO mode. void configureMagMode(rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange): Configure the MAG mode. void configureHeadfreeMode(rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange): Configure the HEADFREE mode.

Example Setting the Receiver Mode and Configuring Flight Modes with AUX channels only for PPM Receiver Mode

/**
 * Configures Pluto's receiver to use PPM or default ESP mode; activate the line matching your setup.
 * AUX channel configurations is only for PPM recievers if no custom configureMode function is called this are the default setup
 * ARM mode : Rx_AUX2, range 1300 to 2100
 * ANGLE mode : Rx_AUX2, range 900 to 2100
 * BARO mode : Rx_AUX3, range 1300 to 2100
 * MAG mode : Rx_AUX1, range 900 to 1300
 * HEADFREE mode : Rx_AUX1, range 1300 to 1700 */ void plutoRxConfig ( void ) {
  // Receiver mode: Uncomment one line for ESP or PPM setup.
  // Receiver.rxMode ( Rx_ESP );    // Onboard ESP
  Receiver.rxMode(Rx_PPM);  // PPM based

  // Configure ARM mode on Rx_AUX4 channel, with ranges from 1300 to 2100
  Receiver.configureArmMode ( Rx_AUX4, 1300, 2100 );

  // Setup additional modes
  Receiver.configureModeANGLE ( Rx_AUX4, 900, 2100 );
  Receiver.configureModeBARO ( Rx_AUX3, 1300, 2100 );
  Receiver.configureMagMode ( Rx_AUX1, 900, 1300 );
  Receiver.configureHeadfreeMode ( Rx_AUX1, 1300, 1700 );
}