### PR TITLE
feat(rx): add support for DEV mode configuration

### DIFF
--- a/src/main/API/PlutoPilot.cpp
+++ b/src/main/API/PlutoPilot.cpp
@@ -9,6 +9,7 @@
  * BARO mode : Rx_AUX3, range 1300 to 2100
  * MAG mode : Rx_AUX1, range 900 to 1300
  * HEADFREE mode : Rx_AUX1, range 1300 to 1700
+ * DEV mode : Rx_AUX4, range 1500 to 2100
  */
 void plutoRxConfig ( void ) {
   // Receiver mode: Uncomment one line for ESP or PPM setup.

--- a/src/main/API/RxConfig.cpp
+++ b/src/main/API/RxConfig.cpp
@@ -5,8 +5,6 @@
 
 #include "platform.h"
 
-// #include "build_config.h"
-
 #include "common/color.h"
 #include "common/axis.h"
 #include "common/maths.h"
@@ -14,30 +12,18 @@
 #include "drivers/sensor.h"
 #include "drivers/accgyro.h"
 #include "drivers/compass.h"
-// #include "drivers/system.h"
-// #include "drivers/gpio.h"
-// #include "drivers/timer.h"
-// #include "drivers/pwm_rx.h"
 #include "drivers/serial.h"
 
 #include "sensors/sensors.h"
 #include "sensors/gyro.h"
-// #include "sensors/compass.h"
 #include "sensors/acceleration.h"
 #include "sensors/barometer.h"
 #include "sensors/boardalignment.h"
 #include "sensors/battery.h"
 
-// #include "io/beeper.h"
 #include "io/serial.h"
-// #include "io/gimbal.h"
-// #include "io/escservo.h"
 #include "io/rc_controls.h"
-// #include "io/rc_curves.h"
-// #include "io/ledstrip.h"
-// #include "io/gps.h"
 
-// #include "rx/rx.h"
 
 #include "telemetry/telemetry.h"
 
@@ -45,10 +31,8 @@
 #include "flight/pid.h"
 #include "flight/imu.h"
 #include "flight/failsafe.h"
-// #include "flight/altitudehold.h"
 #include "flight/navigation.h"
-// #include "flight/posControl.h"
-// #include "flight/posEstimate.h"
+
 
 #include "config/runtime_config.h"
 #include "config/config.h"
@@ -58,11 +42,7 @@
 
 #include "PlutoPilot.h"
 #include "RxConfig.h"
-// #include "config/config_profile.h"
-// #include "config/config_master.h"
 
-
-// #include "io/rc_controls.h"
 
 
 
@@ -76,22 +56,22 @@ rx_mode_e RxMode = Rx_ESP;
  * @param minRange The minimum range value for activation.
  * @param maxRange The maximum range value for activation.
  */
-void Rc_Rx_Config_P::configAUX(flight_mode flightMode, rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange) {
-  switch (flightMode) {
+void Rc_Rx_Config_P::configAUX ( flight_mode flightMode, rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange ) {
+  switch ( flightMode ) {
     case Mode_ARM:
-      currentProfile->modeActivationConditions[0] = {(boxId_e)BOXARM, rxChannel - NON_AUX_CHANNEL_COUNT, CHANNEL_VALUE_TO_STEP(minRange), CHANNEL_VALUE_TO_STEP(maxRange)};
+      currentProfile->modeActivationConditions [ 0 ] = { ( boxId_e ) BOXARM, rxChannel - NON_AUX_CHANNEL_COUNT, CHANNEL_VALUE_TO_STEP ( minRange ), CHANNEL_VALUE_TO_STEP ( maxRange ) };
       break;
     case Mode_ANGLE:
-      currentProfile->modeActivationConditions[1] = {(boxId_e)BOXANGLE, rxChannel - NON_AUX_CHANNEL_COUNT, CHANNEL_VALUE_TO_STEP(minRange), CHANNEL_VALUE_TO_STEP(maxRange)};
+      currentProfile->modeActivationConditions [ 1 ] = { ( boxId_e ) BOXANGLE, rxChannel - NON_AUX_CHANNEL_COUNT, CHANNEL_VALUE_TO_STEP ( minRange ), CHANNEL_VALUE_TO_STEP ( maxRange ) };
       break;
     case Mode_BARO:
-      currentProfile->modeActivationConditions[2] = {(boxId_e)BOXBARO, rxChannel - NON_AUX_CHANNEL_COUNT, CHANNEL_VALUE_TO_STEP(minRange), CHANNEL_VALUE_TO_STEP(maxRange)};
+      currentProfile->modeActivationConditions [ 2 ] = { ( boxId_e ) BOXBARO, rxChannel - NON_AUX_CHANNEL_COUNT, CHANNEL_VALUE_TO_STEP ( minRange ), CHANNEL_VALUE_TO_STEP ( maxRange ) };
       break;
     case Mode_MAG:
-      currentProfile->modeActivationConditions[3] = {(boxId_e)BOXMAG, rxChannel - NON_AUX_CHANNEL_COUNT, CHANNEL_VALUE_TO_STEP(minRange), CHANNEL_VALUE_TO_STEP(maxRange)};
+      currentProfile->modeActivationConditions [ 3 ] = { ( boxId_e ) BOXMAG, rxChannel - NON_AUX_CHANNEL_COUNT, CHANNEL_VALUE_TO_STEP ( minRange ), CHANNEL_VALUE_TO_STEP ( maxRange ) };
       break;
     case Mode_HEADFREE:
-      currentProfile->modeActivationConditions[4] = {(boxId_e)BOXHEADFREE, rxChannel - NON_AUX_CHANNEL_COUNT, CHANNEL_VALUE_TO_STEP(minRange), CHANNEL_VALUE_TO_STEP(maxRange)};
+      currentProfile->modeActivationConditions [ 4 ] = { ( boxId_e ) BOXHEADFREE, rxChannel - NON_AUX_CHANNEL_COUNT, CHANNEL_VALUE_TO_STEP ( minRange ), CHANNEL_VALUE_TO_STEP ( maxRange ) };
       break;
     default:
       break;
@@ -105,37 +85,39 @@ bool AuxChangeEnable = false;
  *
  * @param rxMode The receiver mode to configure (e.g., Rx_ESP, Rx_PPM).
  */
-void Rc_Rx_Config_P::rxMode(rx_mode_e rxMode) {
-  switch (rxMode) {
+void Rc_Rx_Config_P::rxMode ( rx_mode_e rxMode ) {
+  switch ( rxMode ) {
     case Rx_ESP:
       AuxChangeEnable = false;
-      featureSet(FEATURE_RX_MSP);
-      featureClear(FEATURE_RX_SERIAL);
-      featureClear(FEATURE_RX_PARALLEL_PWM);
-      featureClear(FEATURE_RX_PPM);
+      featureSet ( FEATURE_RX_MSP );
+      featureClear ( FEATURE_RX_SERIAL );
+      featureClear ( FEATURE_RX_PARALLEL_PWM );
+      featureClear ( FEATURE_RX_PPM );
 
       // Configure auxiliary channels for various modes
-      configAUX(Mode_ARM, Rx_AUX4, 1300, 2100);
-      configAUX(Mode_ANGLE, Rx_AUX4, 900, 2100);
-      configAUX(Mode_BARO, Rx_AUX3, 1300, 2100);
-      configAUX(Mode_MAG, Rx_AUX1, 900, 1300);
-      configAUX(Mode_HEADFREE, Rx_AUX1, 1300, 1700);
+      configAUX ( Mode_ARM, Rx_AUX4, 1300, 2100 );
+      configAUX ( Mode_ANGLE, Rx_AUX4, 900, 2100 );
+      configAUX ( Mode_BARO, Rx_AUX3, 1300, 2100 );
+      configAUX ( Mode_MAG, Rx_AUX1, 900, 1300 );
+      configAUX ( Mode_HEADFREE, Rx_AUX1, 1300, 1700 );
+      configureDevMode ( Rx_AUX2, 1400, 1800 );
       break;
 
     case Rx_PPM:
       AuxChangeEnable = true;
 
-      featureSet(FEATURE_RX_PPM);
-      featureClear(FEATURE_RX_SERIAL);
-      featureClear(FEATURE_RX_PARALLEL_PWM);
-      featureClear(FEATURE_RX_MSP);
+      featureSet ( FEATURE_RX_PPM );
+      featureClear ( FEATURE_RX_SERIAL );
+      featureClear ( FEATURE_RX_PARALLEL_PWM );
+      featureClear ( FEATURE_RX_MSP );
 
       // Configure auxiliary channels for various modes
-      configAUX(Mode_ARM, Rx_AUX2, 1300, 2100);
-      configAUX(Mode_ANGLE, Rx_AUX2, 900, 2100);
-      configAUX(Mode_BARO, Rx_AUX3, 1300, 2100);
-      configAUX(Mode_MAG, Rx_AUX1, 900, 1300);
-      configAUX(Mode_HEADFREE, Rx_AUX1, 1300, 1700);
+      configAUX ( Mode_ARM, Rx_AUX2, 1300, 2100 );
+      configAUX ( Mode_ANGLE, Rx_AUX2, 900, 2100 );
+      configAUX ( Mode_BARO, Rx_AUX3, 1300, 2100 );
+      configAUX ( Mode_MAG, Rx_AUX1, 900, 1300 );
+      configAUX ( Mode_HEADFREE, Rx_AUX1, 1300, 1700 );
+      configureDevMode ( Rx_AUX4, 1500, 2100 );
       break;
 
     default:
@@ -150,9 +132,9 @@ void Rc_Rx_Config_P::rxMode(rx_mode_e rxMode) {
  * @param minRange The minimum range value for activation.
  * @param maxRange The maximum range value for activation.
  */
-void Rc_Rx_Config_P::configureArmMode(rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange) {
-  if (AuxChangeEnable) {
-    configAUX(Mode_ARM, rxChannel, minRange, maxRange);
+void Rc_Rx_Config_P::configureArmMode ( rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange ) {
+  if ( AuxChangeEnable ) {
+    configAUX ( Mode_ARM, rxChannel, minRange, maxRange );
   }
 }
 
@@ -163,9 +145,9 @@ void Rc_Rx_Config_P::configureArmMode(rx_channel_e rxChannel, uint16_t minRange,
  * @param minRange The minimum range value for activation.
  * @param maxRange The maximum range value for activation.
  */
-void Rc_Rx_Config_P::configureModeANGLE(rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange) {
-  if (AuxChangeEnable) {
-    configAUX(Mode_ANGLE, rxChannel, minRange, maxRange);
+void Rc_Rx_Config_P::configureModeANGLE ( rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange ) {
+  if ( AuxChangeEnable ) {
+    configAUX ( Mode_ANGLE, rxChannel, minRange, maxRange );
   }
 }
 
@@ -176,9 +158,9 @@ void Rc_Rx_Config_P::configureModeANGLE(rx_channel_e rxChannel, uint16_t minRang
  * @param minRange The minimum range value for activation.
  * @param maxRange The maximum range value for activation.
  */
-void Rc_Rx_Config_P::configureModeBARO(rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange) {
-  if (AuxChangeEnable) {
-    configAUX(Mode_BARO, rxChannel, minRange, maxRange);
+void Rc_Rx_Config_P::configureModeBARO ( rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange ) {
+  if ( AuxChangeEnable ) {
+    configAUX ( Mode_BARO, rxChannel, minRange, maxRange );
   }
 }
 
@@ -189,9 +171,9 @@ void Rc_Rx_Config_P::configureModeBARO(rx_channel_e rxChannel, uint16_t minRange
  * @param minRange The minimum range value for activation.
  * @param maxRange The maximum range value for activation.
  */
-void Rc_Rx_Config_P::configureMagMode(rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange) {
-  if (AuxChangeEnable) {
-    configAUX(Mode_MAG, rxChannel, minRange, maxRange);
+void Rc_Rx_Config_P::configureMagMode ( rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange ) {
+  if ( AuxChangeEnable ) {
+    configAUX ( Mode_MAG, rxChannel, minRange, maxRange );
   }
 }
 
@@ -202,10 +184,35 @@ void Rc_Rx_Config_P::configureMagMode(rx_channel_e rxChannel, uint16_t minRange,
  * @param minRange The minimum range value for activation.
  * @param maxRange The maximum range value for activation.
  */
-void Rc_Rx_Config_P::configureHeadfreeMode(rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange) {
-  if (AuxChangeEnable) {
-    configAUX(Mode_HEADFREE, rxChannel, minRange, maxRange);
+void Rc_Rx_Config_P::configureHeadfreeMode ( rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange ) {
+  if ( AuxChangeEnable ) {
+    configAUX ( Mode_HEADFREE, rxChannel, minRange, maxRange );
   }
+}
+
+// Global variables to store device mode configuration
+uint8_t DevModeAUX = 0;         // Auxiliary channel for device mode
+uint16_t DevModeMinRange = 0;   // Minimum range for device mode
+uint16_t DevModeMaxRange = 0;   // Maximum range for device mode
+
+/**
+ * @brief Configures the device mode with specified parameters.
+ *
+ * This function sets the auxiliary channel, minimum range, and maximum range
+ * for the device mode configuration. The configuration is applied only if 
+ * AuxChangeEnable is true.
+ *
+ * @param rxChannel The auxiliary channel to be used for device mode.
+ * @param minRange The minimum range value for the device mode.
+ * @param maxRange The maximum range value for the device mode.
+ */
+void Rc_Rx_Config_P::configureDevMode(rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange) {
+    // Check if change in auxiliary settings is enabled
+    if (AuxChangeEnable) {
+        DevModeAUX = rxChannel;      // Set the auxiliary channel
+        DevModeMinRange = minRange;  // Set the minimum range
+        DevModeMaxRange = maxRange;  // Set the maximum range
+    }
 }
 
 

--- a/src/main/API/RxConfig.h
+++ b/src/main/API/RxConfig.h
@@ -29,6 +29,11 @@ typedef enum {
 } rx_channel_e;
 
 
+extern uint8_t DevModeAUX;
+extern uint16_t DevModeMinRange;
+extern uint16_t DevModeMaxRange;
+
+
 class Rc_Rx_Config_P {
  private:
   void configAUX ( flight_mode flightMode, rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange );
@@ -41,6 +46,7 @@ class Rc_Rx_Config_P {
   void configureModeBARO ( rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange );
   void configureMagMode ( rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange );
   void configureHeadfreeMode ( rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange );
+  void configureDevMode ( rx_channel_e rxChannel, uint16_t minRange, uint16_t maxRange );
 };
 
 extern Rc_Rx_Config_P Receiver;

--- a/src/main/mw.cpp
+++ b/src/main/mw.cpp
@@ -100,77 +100,78 @@
 #include "API/PlutoPilot.h"
 #include "API/XRanging.h"
 #include "API/Localisation.h"
+#include "API/RxConfig.h"
 #include "command/command.h"
 #include "command/localisationCommand.h"
 #include "drivers/opticflow_paw3903.h"
 
 /* VBAT monitoring interval (in microseconds) - 1s*/
-#define VBATINTERVAL (6 * 3500)
+#define VBATINTERVAL ( 6 * 3500 )
 /* IBat monitoring interval (in microseconds) - 6 default looptimes */
-#define IBATINTERVAL (6 * 3500)
+#define IBATINTERVAL ( 6 * 3500 )
 
-int8_t returnValue = 100;
+int8_t returnValue         = 100;
 uint8_t motorControlEnable = false;
-extern uint8_t dynP8[3];
-extern uint8_t dynI8[3];
-extern uint8_t dynD8[3];
-extern uint8_t PIDweight[3];
+extern uint8_t dynP8 [ 3 ];
+extern uint8_t dynI8 [ 3 ];
+extern uint8_t dynD8 [ 3 ];
+extern uint8_t PIDweight [ 3 ];
 
 int16_t magHold;
 int16_t headFreeModeHold = 83;
 int16_t telemTemperature1;      // gyro sensor temperature
-uint16_t cycleTime = 0; // this is the number in micro second to achieve a full loop, it can differ a little and is taken into account in the PID loop
-int16_t stateHandler = 0;
+uint16_t cycleTime      = 0;    // this is the number in micro second to achieve a full loop, it can differ a little and is taken into account in the PID loop
+int16_t stateHandler    = 0;
 int16_t startEstimation = 0;
 
-uint32_t currentTime = 0;
+uint32_t currentTime  = 0;
 uint32_t previousTime = 0;
 uint32_t timeNow;
 uint32_t timeDifference;
-uint32_t add1 = 23;
-uint32_t debugThrottle = 10;
+uint32_t add1           = 23;
+uint32_t debugThrottle  = 10;
 uint32_t debugThrottle1 = 20;
-uint32_t current_time = 0;
-uint32_t total_time = 0;
-uint32_t previous_time = 0;
-uint32_t mode_checker = 0;
-static uint32_t disarmAt; // Time of automatic disarm when "Don't spin the motors when armed" is enabled and auto_disarm_delay is nonzero
+uint32_t current_time   = 0;
+uint32_t total_time     = 0;
+uint32_t previous_time  = 0;
+uint32_t mode_checker   = 0;
+static uint32_t disarmAt;    // Time of automatic disarm when "Don't spin the motors when armed" is enabled and auto_disarm_delay is nonzero
 
 uint32_t userCurrentTime = 0;
-uint32_t userLoopTime = 0;
+uint32_t userLoopTime    = 0;
 
 bool receivingRxData;
-bool isHeadSet = false;
-bool isCalibrated = false;
-bool shouldStart = false;
-bool tookOff = false;
+bool isHeadSet          = false;
+bool isCalibrated       = false;
+bool shouldStart        = false;
+bool tookOff            = false;
 bool crashRecoveryCheck = false;
 static bool isRXDataNew;
 static bool isBatteryLow = false;
-uint32_t arm_time = 0;
+uint32_t arm_time        = 0;
 
 bool isBlackboxOn = false;
 
-//bool isFlipDone=false;
-//bool startStable=false;
+// bool isFlipDone=false;
+// bool startStable=false;
 
 enum {
-    ALIGN_GYRO = 0,
-    ALIGN_ACCEL = 1,
-    ALIGN_MAG = 2
+  ALIGN_GYRO  = 0,
+  ALIGN_ACCEL = 1,
+  ALIGN_MAG   = 2
 };
 
-//Interval crashTimer;
+// Interval crashTimer;
 
-Interval dataLog; // Timer for controlling logging interval
+Interval dataLog;    // Timer for controlling logging interval
 
-int16_t myRC[8] = { 1500, 1500, 1500, 1500, 1500, 1500, 1500, 1500 };
+int16_t myRC [ 8 ] = { 1500, 1500, 1500, 1500, 1500, 1500, 1500, 1500 };
 
-typedef void (*pidControllerFuncPtr)(pidProfile_t *pidProfile, controlRateConfig_t *controlRateConfig, uint16_t max_angle_inclination, rollAndPitchTrims_t *angleTrim, rxConfig_t *rxConfig); // pid controller function prototype
+typedef void ( *pidControllerFuncPtr ) ( pidProfile_t *pidProfile, controlRateConfig_t *controlRateConfig, uint16_t max_angle_inclination, rollAndPitchTrims_t *angleTrim, rxConfig_t *rxConfig );    // pid controller function prototype
 
 extern pidControllerFuncPtr pid_controller;
 
-uint8_t getPos[2] = { 0x02, 0x00 };
+uint8_t getPos [ 2 ] = { 0x02, 0x00 };
 uint8_t ch;
 
 Interval UartTimer;
@@ -181,1129 +182,1075 @@ uint32_t Uwbtime;
 // UWB Data Read
 
 #ifdef UWB
-void uwbUpdate()
-{
+void uwbUpdate ( ) {
 
-    if (GPIO.read(Pin8)) { //When UWB TAG gets new data GPIO 8 on UNIBUS gets HIGH: works as a ready flag
+  if ( GPIO.read ( Pin8 ) ) {    // When UWB TAG gets new data GPIO 8 on UNIBUS gets HIGH: works as a ready flag
 
-        LED_M_TOGGLE; // Toggling green LED for data received indication
+    LED_M_TOGGLE;                // Toggling green LED for data received indication
 
-        UART.write(UART2, getPos, 2);
+    UART.write ( UART2, getPos, 2 );
 
-        while (UART.rxBytesWaiting(UART2)) {
-            ch = UART.read8(UART2);
-            if (ch == 0x40) {
-                ch = UART.read8(UART2);
-                if (ch == 0x01) {
-                    ch = UART.read8(UART2);
-                    if (ch == 0x00) {
-                        ch = UART.read8(UART2);
-                        if (ch == 0x41) {
-                            ch = UART.read8(UART2);
-                            posX = (int16_t)(((int32_t) UART.read32(UART2)) / 10);
-                            posY = (int16_t)(((int32_t) UART.read32(UART2)) / 10);
-                            posZ = (int16_t)(((int32_t) UART.read32(UART2)) / 10);
-                            Quality = (int8_t)((int32_t) UART.read8(UART2));
+    while ( UART.rxBytesWaiting ( UART2 ) ) {
+      ch = UART.read8 ( UART2 );
+      if ( ch == 0x40 ) {
+        ch = UART.read8 ( UART2 );
+        if ( ch == 0x01 ) {
+          ch = UART.read8 ( UART2 );
+          if ( ch == 0x00 ) {
+            ch = UART.read8 ( UART2 );
+            if ( ch == 0x41 ) {
+              ch      = UART.read8 ( UART2 );
+              posX    = ( int16_t ) ( ( ( int32_t ) UART.read32 ( UART2 ) ) / 10 );
+              posY    = ( int16_t ) ( ( ( int32_t ) UART.read32 ( UART2 ) ) / 10 );
+              posZ    = ( int16_t ) ( ( ( int32_t ) UART.read32 ( UART2 ) ) / 10 );
+              Quality = ( int8_t ) ( ( int32_t ) UART.read8 ( UART2 ) );
 
-                            if (Quality > 51)  // only if quality is greater than 50% take as a new position
-                                new_position = true;
-                        }
-                    }
-                }
+              if ( Quality > 51 )    // only if quality is greater than 50% take as a new position
+                new_position = true;
             }
+          }
         }
+      }
     }
+  }
 }
 
 #endif
 
-void applyAndSaveAccelerometerTrimsDelta(rollAndPitchTrims_t *rollAndPitchTrimsDelta)
-{
-    currentProfile->accelerometerTrims.values.roll += rollAndPitchTrimsDelta->values.roll;
-    currentProfile->accelerometerTrims.values.pitch += rollAndPitchTrimsDelta->values.pitch;
-    saveConfigAndNotify();
+void applyAndSaveAccelerometerTrimsDelta ( rollAndPitchTrims_t *rollAndPitchTrimsDelta ) {
+  currentProfile->accelerometerTrims.values.roll += rollAndPitchTrimsDelta->values.roll;
+  currentProfile->accelerometerTrims.values.pitch += rollAndPitchTrimsDelta->values.pitch;
+  saveConfigAndNotify ( );
 }
 
 #ifdef GTUNE
 
-void updateGtuneState(void)
-{
-    static bool GTuneWasUsed = false;
+void updateGtuneState ( void ) {
+  static bool GTuneWasUsed = false;
 
-    if (IS_RC_MODE_ACTIVE(BOXGTUNE)) {
-        if (!FLIGHT_MODE(GTUNE_MODE) && ARMING_FLAG(ARMED)) {
-            ENABLE_FLIGHT_MODE(GTUNE_MODE);
-            init_Gtune(&currentProfile->pidProfile);
-            GTuneWasUsed = true;
-        }
-        if (!FLIGHT_MODE(GTUNE_MODE) && !ARMING_FLAG(ARMED) && GTuneWasUsed) {
-            saveConfigAndNotify();
-            GTuneWasUsed = false;
-        }
-    } else {
-        if (FLIGHT_MODE(GTUNE_MODE) && ARMING_FLAG(ARMED)) {
-            DISABLE_FLIGHT_MODE(GTUNE_MODE);
-        }
+  if ( IS_RC_MODE_ACTIVE ( BOXGTUNE ) ) {
+    if ( ! FLIGHT_MODE ( GTUNE_MODE ) && ARMING_FLAG ( ARMED ) ) {
+      ENABLE_FLIGHT_MODE ( GTUNE_MODE );
+      init_Gtune ( &currentProfile->pidProfile );
+      GTuneWasUsed = true;
     }
+    if ( ! FLIGHT_MODE ( GTUNE_MODE ) && ! ARMING_FLAG ( ARMED ) && GTuneWasUsed ) {
+      saveConfigAndNotify ( );
+      GTuneWasUsed = false;
+    }
+  } else {
+    if ( FLIGHT_MODE ( GTUNE_MODE ) && ARMING_FLAG ( ARMED ) ) {
+      DISABLE_FLIGHT_MODE ( GTUNE_MODE );
+    }
+  }
 }
 #endif
 
-bool isCalibrating()
-{
+bool isCalibrating ( ) {
 
-/*
-#ifdef BARO
-    if (sensors(SENSOR_BARO) && !isBaroCalibrationComplete()) {
-        //return true;
-    }
-#endif
-*/
-    // Note: compass calibration is handled completely differently, outside of the main loop, see f.CALIBRATE_MAG
+  /*
+  #ifdef BARO
+      if (sensors(SENSOR_BARO) && !isBaroCalibrationComplete()) {
+          //return true;
+      }
+  #endif
+  */
+  // Note: compass calibration is handled completely differently, outside of the main loop, see f.CALIBRATE_MAG
 #ifdef MAG_ENFORCE
-    //to check whether mag calibration is done, if not the don't arm
-    if(masterConfig.magScale.raw[0] == 0 || masterConfig.magScale.raw[1] == 0 || masterConfig.magScale.raw[2] == 0) {
-        set_FSI(Mag_Calibration);
-    }
-    else {
-        reset_FSI(Mag_Calibration);
-    }
+  // to check whether mag calibration is done, if not the don't arm
+  if ( masterConfig.magScale.raw [ 0 ] == 0 || masterConfig.magScale.raw [ 1 ] == 0 || masterConfig.magScale.raw [ 2 ] == 0 ) {
+    set_FSI ( Mag_Calibration );
+  } else {
+    reset_FSI ( Mag_Calibration );
+  }
 #endif
-    if (isAccelerationCalibrationComplete() && isGyroCalibrationComplete())
-        reset_FSI(Accel_Gyro_Calibration);
-    else
-        set_FSI(Accel_Gyro_Calibration);
+  if ( isAccelerationCalibrationComplete ( ) && isGyroCalibrationComplete ( ) )
+    reset_FSI ( Accel_Gyro_Calibration );
+  else
+    set_FSI ( Accel_Gyro_Calibration );
 
-    return (status_FSI(Accel_Gyro_Calibration) || accZoffsetCalCycle
+  return ( status_FSI ( Accel_Gyro_Calibration ) || accZoffsetCalCycle
 #ifdef MAG_ENFORCE
-    ||status_FSI(Mag_Calibration)
+           || status_FSI ( Mag_Calibration )
 #endif
-    );
+  );
 }
 
-void annexCode(void)
-{
-    int32_t tmp;
-    int32_t tmp2;
-    int32_t axis;
-    int32_t prop1 = 0;
-    int32_t prop2;
+void annexCode ( void ) {
+  int32_t tmp;
+  int32_t tmp2;
+  int32_t axis;
+  int32_t prop1 = 0;
+  int32_t prop2;
 
-    static uint32_t vbatLastServiced = 0;
-    static uint32_t ibatLastServiced = 0;
+  static uint32_t vbatLastServiced = 0;
+  static uint32_t ibatLastServiced = 0;
 
-    if (rcData[THROTTLE] < currentControlRateProfile->tpa_breakpoint) {
-        prop2 = 100;
+  if ( rcData [ THROTTLE ] < currentControlRateProfile->tpa_breakpoint ) {
+    prop2 = 100;
+  } else {
+    if ( rcData [ THROTTLE ] < 2000 ) {
+      prop2 = 100 - ( uint16_t ) currentControlRateProfile->dynThrPID * ( rcData [ THROTTLE ] - currentControlRateProfile->tpa_breakpoint ) / ( 2000 - currentControlRateProfile->tpa_breakpoint );
     } else {
-        if (rcData[THROTTLE] < 2000) {
-            prop2 = 100 - (uint16_t) currentControlRateProfile->dynThrPID * (rcData[THROTTLE] - currentControlRateProfile->tpa_breakpoint) / (2000 - currentControlRateProfile->tpa_breakpoint);
+      prop2 = 100 - currentControlRateProfile->dynThrPID;
+    }
+  }
+
+  for ( axis = 0; axis < 3; axis++ ) {
+    tmp = MIN ( ABS ( rcData [ axis ] - masterConfig.rxConfig.midrc ), 500 );
+    if ( axis == ROLL || axis == PITCH ) {
+      if ( currentProfile->rcControlsConfig.deadband ) {
+        if ( tmp > currentProfile->rcControlsConfig.deadband ) {
+          tmp -= currentProfile->rcControlsConfig.deadband;
         } else {
-            prop2 = 100 - currentControlRateProfile->dynThrPID;
+          tmp = 0;
         }
-    }
+      }
 
-    for (axis = 0; axis < 3; axis++) {
-        tmp = MIN(ABS(rcData[axis] - masterConfig.rxConfig.midrc), 500);
-        if (axis == ROLL || axis == PITCH) {
-            if (currentProfile->rcControlsConfig.deadband) {
-                if (tmp > currentProfile->rcControlsConfig.deadband) {
-                    tmp -= currentProfile->rcControlsConfig.deadband;
-                } else {
-                    tmp = 0;
-                }
-            }
+      tmp2               = tmp / 100;
+      rcCommand [ axis ] = lookupPitchRollRC [ tmp2 ] + ( tmp - tmp2 * 100 ) * ( lookupPitchRollRC [ tmp2 + 1 ] - lookupPitchRollRC [ tmp2 ] ) / 100;
+      prop1              = 100 - ( uint16_t ) currentControlRateProfile->rates [ axis ] * tmp / 500;
+      prop1              = ( uint16_t ) prop1 * prop2 / 100;
 
-            tmp2 = tmp / 100;
-            rcCommand[axis] = lookupPitchRollRC[tmp2] + (tmp - tmp2 * 100) * (lookupPitchRollRC[tmp2 + 1] - lookupPitchRollRC[tmp2]) / 100;
-            prop1 = 100 - (uint16_t) currentControlRateProfile->rates[axis] * tmp / 500;
-            prop1 = (uint16_t) prop1 * prop2 / 100;
-
-        } else if (axis == YAW) {
-            if (currentProfile->rcControlsConfig.yaw_deadband) {
-                if (tmp > currentProfile->rcControlsConfig.yaw_deadband) {
-                    tmp -= currentProfile->rcControlsConfig.yaw_deadband;
-                } else {
-                    tmp = 0;
-                }
-            }
-            tmp2 = tmp / 100;
-            rcCommand[axis] = (lookupYawRC[tmp2] + (tmp - tmp2 * 100) * (lookupYawRC[tmp2 + 1] - lookupYawRC[tmp2]) / 100) * -masterConfig.yaw_control_direction;
-            prop1 = 100 - (uint16_t) currentControlRateProfile->rates[axis] * ABS(tmp) / 500;
-        }
-        // FIXME axis indexes into pids.  use something like lookupPidIndex(rc_alias_e alias) to reduce coupling.
-        dynP8[axis] = (uint16_t) currentProfile->pidProfile.P8[axis] * prop1 / 100;
-        dynI8[axis] = (uint16_t) currentProfile->pidProfile.I8[axis] * prop1 / 100;
-        dynD8[axis] = (uint16_t) currentProfile->pidProfile.D8[axis] * prop1 / 100;
-
-        // non coupled PID reduction scaler used in PID controller 1 and PID controller 2. YAW TPA disabled. 100 means 100% of the pids
-        if (axis == YAW) {
-            PIDweight[axis] = 100;
+    } else if ( axis == YAW ) {
+      if ( currentProfile->rcControlsConfig.yaw_deadband ) {
+        if ( tmp > currentProfile->rcControlsConfig.yaw_deadband ) {
+          tmp -= currentProfile->rcControlsConfig.yaw_deadband;
         } else {
-            PIDweight[axis] = prop2;
+          tmp = 0;
         }
-
-        if (rcData[axis] < masterConfig.rxConfig.midrc)
-            rcCommand[axis] = -rcCommand[axis];
+      }
+      tmp2               = tmp / 100;
+      rcCommand [ axis ] = ( lookupYawRC [ tmp2 ] + ( tmp - tmp2 * 100 ) * ( lookupYawRC [ tmp2 + 1 ] - lookupYawRC [ tmp2 ] ) / 100 ) * -masterConfig.yaw_control_direction;
+      prop1              = 100 - ( uint16_t ) currentControlRateProfile->rates [ axis ] * ABS ( tmp ) / 500;
     }
+    // FIXME axis indexes into pids.  use something like lookupPidIndex(rc_alias_e alias) to reduce coupling.
+    dynP8 [ axis ] = ( uint16_t ) currentProfile->pidProfile.P8 [ axis ] * prop1 / 100;
+    dynI8 [ axis ] = ( uint16_t ) currentProfile->pidProfile.I8 [ axis ] * prop1 / 100;
+    dynD8 [ axis ] = ( uint16_t ) currentProfile->pidProfile.D8 [ axis ] * prop1 / 100;
 
-    if (limitAltitude() && rcData[THROTTLE] > 1500) {
-        rcData[THROTTLE] = 1500;
-
-    }
-
-    if (isLanding) {
-        rcData[THROTTLE] = landThrottle;
-
-    }
-
-    tmp = constrain(rcData[THROTTLE], masterConfig.rxConfig.mincheck, PWM_RANGE_MAX);
-    tmp = (uint32_t)(tmp - masterConfig.rxConfig.mincheck) * PWM_RANGE_MIN / (PWM_RANGE_MAX - masterConfig.rxConfig.mincheck); // [MINCHECK;2000] -> [0;1000]
-    tmp2 = tmp / 100;
-    rcCommand[THROTTLE] = lookupThrottleRC[tmp2] + (tmp - tmp2 * 100) * (lookupThrottleRC[tmp2 + 1] - lookupThrottleRC[tmp2]) / 100; // [0;1000] -> expo -> [MINTHROTTLE;MAXTHROTTLE]
-
-    if (isLocalisationOn && ARMING_FLAG(ARMED)) {	// for localisation
-        rcCommand[ROLL] = getrcDataRoll();
-        rcCommand[PITCH] = getrcDataPitch();
-
+    // non coupled PID reduction scaler used in PID controller 1 and PID controller 2. YAW TPA disabled. 100 means 100% of the pids
+    if ( axis == YAW ) {
+      PIDweight [ axis ] = 100;
     } else {
-
-        resetPosIntegral();
-        command_jump(-1);
+      PIDweight [ axis ] = prop2;
     }
 
-    if (FLIGHT_MODE(HEADFREE_MODE)) {
-        float radDiff = degreesToRadians(heading - headFreeModeHold);
-        float cosDiff = cos_approx(radDiff);
-        float sinDiff = sin_approx(radDiff);
-        int16_t rcCommand_PITCH = rcCommand[PITCH] * cosDiff + rcCommand[ROLL] * sinDiff;
-        rcCommand[ROLL] = rcCommand[ROLL] * cosDiff - rcCommand[PITCH] * sinDiff;
-        rcCommand[PITCH] = rcCommand_PITCH;
+    if ( rcData [ axis ] < masterConfig.rxConfig.midrc )
+      rcCommand [ axis ] = -rcCommand [ axis ];
+  }
+
+  if ( limitAltitude ( ) && rcData [ THROTTLE ] > 1500 ) {
+    rcData [ THROTTLE ] = 1500;
+  }
+
+  if ( isLanding ) {
+    rcData [ THROTTLE ] = landThrottle;
+  }
+
+  tmp                    = constrain ( rcData [ THROTTLE ], masterConfig.rxConfig.mincheck, PWM_RANGE_MAX );
+  tmp                    = ( uint32_t ) ( tmp - masterConfig.rxConfig.mincheck ) * PWM_RANGE_MIN / ( PWM_RANGE_MAX - masterConfig.rxConfig.mincheck );    // [MINCHECK;2000] -> [0;1000]
+  tmp2                   = tmp / 100;
+  rcCommand [ THROTTLE ] = lookupThrottleRC [ tmp2 ] + ( tmp - tmp2 * 100 ) * ( lookupThrottleRC [ tmp2 + 1 ] - lookupThrottleRC [ tmp2 ] ) / 100;        // [0;1000] -> expo -> [MINTHROTTLE;MAXTHROTTLE]
+
+  if ( isLocalisationOn && ARMING_FLAG ( ARMED ) ) {                                                                                                      // for localisation
+    rcCommand [ ROLL ]  = getrcDataRoll ( );
+    rcCommand [ PITCH ] = getrcDataPitch ( );
+
+  } else {
+
+    resetPosIntegral ( );
+    command_jump ( -1 );
+  }
+
+  if ( FLIGHT_MODE ( HEADFREE_MODE ) ) {
+    float radDiff           = degreesToRadians ( heading - headFreeModeHold );
+    float cosDiff           = cos_approx ( radDiff );
+    float sinDiff           = sin_approx ( radDiff );
+    int16_t rcCommand_PITCH = rcCommand [ PITCH ] * cosDiff + rcCommand [ ROLL ] * sinDiff;
+    rcCommand [ ROLL ]      = rcCommand [ ROLL ] * cosDiff - rcCommand [ PITCH ] * sinDiff;
+    rcCommand [ PITCH ]     = rcCommand_PITCH;
+  }
+
+  if ( feature ( FEATURE_VBAT ) ) {
+    if ( cmp32 ( currentTime, vbatLastServiced ) >= VBATINTERVAL ) {
+      vbatLastServiced = currentTime;
+      updateBattery ( );
+    }
+  }
+
+  if ( feature ( FEATURE_CURRENT_METER ) ) {
+    int32_t ibatTimeSinceLastServiced = cmp32 ( currentTime, ibatLastServiced );
+
+    if ( ibatTimeSinceLastServiced >= IBATINTERVAL ) {
+      ibatLastServiced = currentTime;
+      updateCurrentMeter ( ibatTimeSinceLastServiced, &masterConfig.rxConfig, masterConfig.flight3DConfig.deadband3d_throttle );
+    }
+  }
+
+  beeperUpdate ( );    // call periodic beeper handler
+
+  if ( ARMING_FLAG ( ARMED ) ) {
+    set_FSI ( Armed );
+    reset_FSI ( Ok_to_arm );
+    reset_FSI ( Not_ok_to_arm );
+  } else {
+    reset_FSI ( Armed );
+    if ( IS_RC_MODE_ACTIVE ( BOXARM ) == 0 ) {
+
+      // LED_L_ON;
+      if ( ! STATE ( SMALL_ANGLE ) || ! isCalibrated ) {
+        DISABLE_ARMING_FLAG ( OK_TO_ARM );
+        reset_FSI ( Ok_to_arm );
+        set_FSI ( Not_ok_to_arm );
+      } else {
+
+        ENABLE_ARMING_FLAG ( OK_TO_ARM );
+        set_FSI ( Ok_to_arm );
+        reset_FSI ( Not_ok_to_arm );
+      }
     }
 
-    if (feature(FEATURE_VBAT)) {
-        if (cmp32(currentTime, vbatLastServiced) >= VBATINTERVAL) {
-            vbatLastServiced = currentTime;
-            updateBattery();
-        }
+    if ( status_FSI ( Crash ) && ! crashRecoveryCheck ) {
+
+      if ( crashTimer.set ( 300, false ) ) {
+
+        crashRecoveryCheck = true;
+        crashTimer.reset ( );
+      }
     }
 
-    if (feature(FEATURE_CURRENT_METER)) {
-        int32_t ibatTimeSinceLastServiced = cmp32(currentTime, ibatLastServiced);
-
-        if (ibatTimeSinceLastServiced >= IBATINTERVAL) {
-            ibatLastServiced = currentTime;
-            updateCurrentMeter(ibatTimeSinceLastServiced, &masterConfig.rxConfig, masterConfig.flight3DConfig.deadband3d_throttle);
-        }
+    if ( crashRecoveryCheck && STATE ( SMALL_ANGLE ) ) {
+      reset_FSI ( Crash );
+      crashRecoveryCheck = false;
     }
 
-    beeperUpdate();          //call periodic beeper handler
+    if ( vbat > 34 ) {
+      isBatteryLow = false;
+      // ENABLE_ARMING_FLAG(OK_TO_ARM);???
+      reset_FSI ( Low_battery );
+    } else if ( fsLowBattery ) {
+      isBatteryLow = true;
+      set_FSI ( Low_battery );
+    }
+    //   }
 
-    if (ARMING_FLAG(ARMED)) {
-        set_FSI(Armed);
-        reset_FSI(Ok_to_arm);
-        reset_FSI(Not_ok_to_arm);
+    if ( isCalibrating ( ) ) {
+      warningLedFlash ( );
+      DISABLE_ARMING_FLAG ( OK_TO_ARM );
+      // flightIndicatorFlag|=(1<<Accel_Gyro_Calibration);
     } else {
-        reset_FSI(Armed);
-        if (IS_RC_MODE_ACTIVE(BOXARM) == 0) {
-
-            //LED_L_ON;
-            if (!STATE(SMALL_ANGLE) || !isCalibrated) {
-                DISABLE_ARMING_FLAG(OK_TO_ARM);
-                reset_FSI(Ok_to_arm);
-                set_FSI(Not_ok_to_arm);
-            } else {
-
-                ENABLE_ARMING_FLAG(OK_TO_ARM);
-                set_FSI(Ok_to_arm);
-                reset_FSI(Not_ok_to_arm);
-            }
-
-        }
-
-        if (status_FSI(Crash) && !crashRecoveryCheck) {
-
-            if (crashTimer.set(300, false)) {
-
-                crashRecoveryCheck = true;
-                crashTimer.reset();
-
-            }
-        }
-
-        if (crashRecoveryCheck && STATE(SMALL_ANGLE)) {
-            reset_FSI(Crash);
-            crashRecoveryCheck = false;
-        }
-
-        if (vbat > 34) {
-            isBatteryLow = false;
-            //ENABLE_ARMING_FLAG(OK_TO_ARM);???
-            reset_FSI(Low_battery);
-        } else if (fsLowBattery) {
-            isBatteryLow = true;
-            set_FSI(Low_battery);
-
-        }
-        //   }
-
-        if (isCalibrating()) {
-            warningLedFlash();
-            DISABLE_ARMING_FLAG(OK_TO_ARM);
-            //flightIndicatorFlag|=(1<<Accel_Gyro_Calibration);
-        } else {
-            //flightIndicatorFlag&=~(1<<Accel_Gyro_Calibration);
-            if (ARMING_FLAG(OK_TO_ARM)) {
-                warningLedDisable();
-            } else {
-                warningLedFlash();
-            }
-        }
+      // flightIndicatorFlag&=~(1<<Accel_Gyro_Calibration);
+      if ( ARMING_FLAG ( OK_TO_ARM ) ) {
+        warningLedDisable ( );
+      } else {
+        warningLedFlash ( );
+      }
+    }
 #ifdef FLIGHT_STATUS_INDICATOR
-        //warningLedUpdate();
+    // warningLedUpdate();
 #endif
-    }
+  }
 
 #ifdef TELEMETRY
-    telemetryCheckState();
+  telemetryCheckState ( );
 #endif
 
-    handleSerial();
+  handleSerial ( );
 
 #ifdef GPS
-    if (sensors(SENSOR_GPS)) {
-        updateGpsIndicator(currentTime);
-    }
+  if ( sensors ( SENSOR_GPS ) ) {
+    updateGpsIndicator ( currentTime );
+  }
 #endif
 
-    // Read out gyro temperature. can use it for something somewhere. maybe get MCU temperature instead? lots of fun possibilities.
-    if (gyro.temperature)
-        gyro.temperature(&telemTemperature1);
-
+  // Read out gyro temperature. can use it for something somewhere. maybe get MCU temperature instead? lots of fun possibilities.
+  if ( gyro.temperature )
+    gyro.temperature ( &telemTemperature1 );
 }
 
-void mwDisarm(void)
-{
+void mwDisarm ( void ) {
 
-    if (ARMING_FLAG(ARMED)) {
-        DISABLE_ARMING_FLAG(ARMED);
-        DISABLE_ARMING_FLAG(OK_TO_ARM);
+  if ( ARMING_FLAG ( ARMED ) ) {
+    DISABLE_ARMING_FLAG ( ARMED );
+    DISABLE_ARMING_FLAG ( OK_TO_ARM );
 
 #ifdef BLACKBOX
-        if (feature(FEATURE_BLACKBOX)) {
-            finishBlackbox();
-        }
+    if ( feature ( FEATURE_BLACKBOX ) ) {
+      finishBlackbox ( );
+    }
 #endif
 
-        beeper(BEEPER_DISARMING);      // emit disarm tone
-    }
+    beeper ( BEEPER_DISARMING );    // emit disarm tone
+  }
 
-    if (current_command != NONE)
-        command_status = FINISHED;
+  if ( current_command != NONE )
+    command_status = FINISHED;
 
-    isLanding = false;
-    setLandTimer = true;
-    setTakeOffAlt = false;
-    setTakeOffThrottle = false;
-    setTakeOffTimer = true;
-    isTookOff = false;
-    isTakeOffHeightSet = false;
-    takeOffThrottle = 950;
-    takeOffHeight = 120;
-    landThrottle = 1200;
-    flipState = 0;
-    arm_time = 0;
-    reset_FSI(LowBattery_inFlight);
-    reset_FSI(Signal_loss);
+  isLanding          = false;
+  setLandTimer       = true;
+  setTakeOffAlt      = false;
+  setTakeOffThrottle = false;
+  setTakeOffTimer    = true;
+  isTookOff          = false;
+  isTakeOffHeightSet = false;
+  takeOffThrottle    = 950;
+  takeOffHeight      = 120;
+  landThrottle       = 1200;
+  flipState          = 0;
+  arm_time           = 0;
+  reset_FSI ( LowBattery_inFlight );
+  reset_FSI ( Signal_loss );
 
-    isPitchStabelised = false;
-    isRollStabelised = false;
-    isHeadSet = false;
-    isChukedArmed = false;
-    isThrottleStickArmed = false;
-    // Control.setFailsafeState(CRASH, true);
+  isPitchStabelised    = false;
+  isRollStabelised     = false;
+  isHeadSet            = false;
+  isChukedArmed        = false;
+  isThrottleStickArmed = false;
+  // Control.setFailsafeState(CRASH, true);
 
-    resetPosController();
-
+  resetPosController ( );
 }
 
-#define TELEMETRY_FUNCTION_MASK (FUNCTION_TELEMETRY_FRSKY | FUNCTION_TELEMETRY_HOTT | FUNCTION_TELEMETRY_MSP | FUNCTION_TELEMETRY_SMARTPORT)
+#define TELEMETRY_FUNCTION_MASK ( FUNCTION_TELEMETRY_FRSKY | FUNCTION_TELEMETRY_HOTT | FUNCTION_TELEMETRY_MSP | FUNCTION_TELEMETRY_SMARTPORT )
 
-void releaseSharedTelemetryPorts(void)
-{
-    serialPort_t *sharedPort = findSharedSerialPort(TELEMETRY_FUNCTION_MASK, FUNCTION_MSP);
-    while (sharedPort) {
-        mspReleasePortIfAllocated(sharedPort);
-        sharedPort = findNextSharedSerialPort(TELEMETRY_FUNCTION_MASK, FUNCTION_MSP);
-    }
+void releaseSharedTelemetryPorts ( void ) {
+  serialPort_t *sharedPort = findSharedSerialPort ( TELEMETRY_FUNCTION_MASK, FUNCTION_MSP );
+  while ( sharedPort ) {
+    mspReleasePortIfAllocated ( sharedPort );
+    sharedPort = findNextSharedSerialPort ( TELEMETRY_FUNCTION_MASK, FUNCTION_MSP );
+  }
 }
 
-void mwArm(void)
-{
+void mwArm ( void ) {
 
-    if ((ARMING_FLAG(OK_TO_ARM) || netAccMagnitude < 2) && isCalibrated && !isBatteryLow) {
-        if (ARMING_FLAG(ARMED)) {
-            return;
-        }
-        if (IS_RC_MODE_ACTIVE(BOXFAILSAFE)) {
-            return;
-        }
-        if (!ARMING_FLAG(PREVENT_ARMING)) {
-            ENABLE_ARMING_FLAG(ARMED);
+  if ( ( ARMING_FLAG ( OK_TO_ARM ) || netAccMagnitude < 2 ) && isCalibrated && ! isBatteryLow ) {
+    if ( ARMING_FLAG ( ARMED ) ) {
+      return;
+    }
+    if ( IS_RC_MODE_ACTIVE ( BOXFAILSAFE ) ) {
+      return;
+    }
+    if ( ! ARMING_FLAG ( PREVENT_ARMING ) ) {
+      ENABLE_ARMING_FLAG ( ARMED );
 
-            if (isUserHeadFreeHoldSet) {
+      if ( isUserHeadFreeHoldSet ) {
 
-                headFreeModeHold = userHeadFreeHoldHeading;
+        headFreeModeHold = userHeadFreeHoldHeading;
 
-            } else
-                headFreeModeHold = heading;
+      } else
+        headFreeModeHold = heading;
 
-            // headFreeModeHold=83;
+      // headFreeModeHold=83;
 
-            arm_time = millis();
+      arm_time = millis ( );
 
 #ifdef BLACKBOX
-            if (feature(FEATURE_BLACKBOX)) {
-                serialPort_t *sharedBlackboxAndMspPort = findSharedSerialPort(FUNCTION_BLACKBOX, FUNCTION_MSP);
-                if (sharedBlackboxAndMspPort) {
-                    mspReleasePortIfAllocated(sharedBlackboxAndMspPort);
-                }
-                  startBlackbox();
-            }
+      if ( feature ( FEATURE_BLACKBOX ) ) {
+        serialPort_t *sharedBlackboxAndMspPort = findSharedSerialPort ( FUNCTION_BLACKBOX, FUNCTION_MSP );
+        if ( sharedBlackboxAndMspPort ) {
+          mspReleasePortIfAllocated ( sharedBlackboxAndMspPort );
+        }
+        startBlackbox ( );
+      }
 #endif
-            disarmAt = millis() + masterConfig.auto_disarm_delay * 1000; // start disarm timeout, will be extended when throttle is nonzero
+      disarmAt = millis ( ) + masterConfig.auto_disarm_delay * 1000;    // start disarm timeout, will be extended when throttle is nonzero
 
-            //beep to indicate arming
+	                      // beep to indicate arming
 #ifdef GPS
-            if (feature(FEATURE_GPS) && STATE(GPS_FIX) && GPS_numSat >= 5)
-                beeper(BEEPER_ARMING_GPS_FIX);
-            else
-                beeper(BEEPER_ARMING);
+      if ( feature ( FEATURE_GPS ) && STATE ( GPS_FIX ) && GPS_numSat >= 5 )
+        beeper ( BEEPER_ARMING_GPS_FIX );
+      else
+        beeper ( BEEPER_ARMING );
 #else
-            beeper(BEEPER_ARMING);
+      beeper ( BEEPER_ARMING );
 #endif
 
-            return;
-        }
+      return;
     }
+  }
 
-    if (!ARMING_FLAG(ARMED)) {
-        beeperConfirmationBeeps(1);
-    }
-
+  if ( ! ARMING_FLAG ( ARMED ) ) {
+    beeperConfirmationBeeps ( 1 );
+  }
 }
 
 // Automatic ACC Offset Calibration
-bool AccInflightCalibrationArmed = false;
+bool AccInflightCalibrationArmed           = false;
 bool AccInflightCalibrationMeasurementDone = false;
-bool AccInflightCalibrationSavetoEEProm = false;
-bool AccInflightCalibrationActive = false;
-uint16_t InflightcalibratingA = 0;
+bool AccInflightCalibrationSavetoEEProm    = false;
+bool AccInflightCalibrationActive          = false;
+uint16_t InflightcalibratingA              = 0;
 
-void handleInflightCalibrationStickPosition(void)
-{
-    if (AccInflightCalibrationMeasurementDone) {
-        // trigger saving into eeprom after landing
-        AccInflightCalibrationMeasurementDone = false;
-        AccInflightCalibrationSavetoEEProm = true;
+void handleInflightCalibrationStickPosition ( void ) {
+  if ( AccInflightCalibrationMeasurementDone ) {
+    // trigger saving into eeprom after landing
+    AccInflightCalibrationMeasurementDone = false;
+    AccInflightCalibrationSavetoEEProm    = true;
+  } else {
+    AccInflightCalibrationArmed = ! AccInflightCalibrationArmed;
+    if ( AccInflightCalibrationArmed ) {
+      beeper ( BEEPER_ACC_CALIBRATION );
     } else {
-        AccInflightCalibrationArmed = !AccInflightCalibrationArmed;
-        if (AccInflightCalibrationArmed) {
-            beeper(BEEPER_ACC_CALIBRATION);
-        } else {
-            beeper(BEEPER_ACC_CALIBRATION_FAIL);
-        }
+      beeper ( BEEPER_ACC_CALIBRATION_FAIL );
     }
+  }
 }
 
-void updateInflightCalibrationState(void)
-{
-    if (AccInflightCalibrationArmed && ARMING_FLAG(ARMED) && rcData[THROTTLE] > masterConfig.rxConfig.mincheck && !IS_RC_MODE_ACTIVE(BOXARM)) { // Copter is airborne and you are turning it off via boxarm : start measurement
-        InflightcalibratingA = 50;
-        AccInflightCalibrationArmed = false;
-    }
-    if (IS_RC_MODE_ACTIVE(BOXCALIB)) { // Use the Calib Option to activate : Calib = TRUE Meausrement started, Land and Calib = 0 measurement stored
-        if (!AccInflightCalibrationActive && !AccInflightCalibrationMeasurementDone)
-            InflightcalibratingA = 50;
-        AccInflightCalibrationActive = true;
-    } else if (AccInflightCalibrationMeasurementDone && !ARMING_FLAG(ARMED)) {
-        AccInflightCalibrationMeasurementDone = false;
-        AccInflightCalibrationSavetoEEProm = true;
-    }
+void updateInflightCalibrationState ( void ) {
+  if ( AccInflightCalibrationArmed && ARMING_FLAG ( ARMED ) && rcData [ THROTTLE ] > masterConfig.rxConfig.mincheck && ! IS_RC_MODE_ACTIVE ( BOXARM ) ) {    // Copter is airborne and you are turning it off via boxarm : start measurement
+    InflightcalibratingA        = 50;
+    AccInflightCalibrationArmed = false;
+  }
+  if ( IS_RC_MODE_ACTIVE ( BOXCALIB ) ) {    // Use the Calib Option to activate : Calib = TRUE Meausrement started, Land and Calib = 0 measurement stored
+    if ( ! AccInflightCalibrationActive && ! AccInflightCalibrationMeasurementDone )
+      InflightcalibratingA = 50;
+    AccInflightCalibrationActive = true;
+  } else if ( AccInflightCalibrationMeasurementDone && ! ARMING_FLAG ( ARMED ) ) {
+    AccInflightCalibrationMeasurementDone = false;
+    AccInflightCalibrationSavetoEEProm    = true;
+  }
 }
 
-void updateMagHold(void)
-{
-    static bool isMagHoldChanged = false;
-    int16_t headingError;
+void updateMagHold ( void ) {
+  static bool isMagHoldChanged = false;
+  int16_t headingError;
 
-    if (ABS(rcData[YAW]-1500) < 300 && (FLIGHT_MODE(MAG_MODE) || FLIGHT_MODE(HEADFREE_MODE))) {
+  if ( ABS ( rcData [ YAW ] - 1500 ) < 300 && ( FLIGHT_MODE ( MAG_MODE ) || FLIGHT_MODE ( HEADFREE_MODE ) ) ) {
 
-        if (isMagHoldChanged && ABS(gyroADC[YAW]/4) < 70) {
-            isMagHoldChanged = false;
-            magHold = heading;
-
-        }
-
-        if (!isMagHoldChanged) {
-            headingError = heading - magHold;
-            if (headingError <= -180)
-                headingError += 360;
-            if (headingError >= +180)
-                headingError -= 360;
-
-            headingError = constrain(headingError, -30, 30);
-
-            rcCommand[YAW] = headingError * currentProfile->pidProfile.P8[PIDMAG];
-            rcCommand[YAW] = constrain(rcCommand[YAW], -400, 400);
-
-        }
-
-    } else {
-
-        isMagHoldChanged = true;
-        magHold = heading;
+    if ( isMagHoldChanged && ABS ( gyroADC [ YAW ] / 4 ) < 70 ) {
+      isMagHoldChanged = false;
+      magHold          = heading;
     }
 
+    if ( ! isMagHoldChanged ) {
+      headingError = heading - magHold;
+      if ( headingError <= -180 )
+        headingError += 360;
+      if ( headingError >= +180 )
+        headingError -= 360;
+
+      headingError = constrain ( headingError, -30, 30 );
+
+      rcCommand [ YAW ] = headingError * currentProfile->pidProfile.P8 [ PIDMAG ];
+      rcCommand [ YAW ] = constrain ( rcCommand [ YAW ], -400, 400 );
+    }
+
+  } else {
+
+    isMagHoldChanged = true;
+    magHold          = heading;
+  }
 }
 
 typedef enum {
 #ifdef MAG
-    UPDATE_COMPASS_TASK,
+  UPDATE_COMPASS_TASK,
 #endif
 #ifdef BARO
-    UPDATE_BARO_TASK,
+  UPDATE_BARO_TASK,
 #endif
 #ifdef SONAR
-    UPDATE_SONAR_TASK,
+  UPDATE_SONAR_TASK,
 #endif
-#if defined(BARO) || defined(SONAR)
-    CALCULATE_ALTITUDE_TASK,
+#if defined( BARO ) || defined( SONAR )
+  CALCULATE_ALTITUDE_TASK,
 #endif
 #ifdef DISPLAY
-    UPDATE_DISPLAY_TASK,
+  UPDATE_DISPLAY_TASK,
 #endif
 
-    UPDATE_OPTICFLOW,
+  UPDATE_OPTICFLOW,
 
-    UPDATE_LASER_TOF_TASK,
+  UPDATE_LASER_TOF_TASK,
 
 } periodicTasks;
 
-#define PERIODIC_TASK_COUNT (UPDATE_LASER_TOF_TASK+1)
+#define PERIODIC_TASK_COUNT ( UPDATE_LASER_TOF_TASK + 1 )
 
-void executePeriodicTasks(void)
-{
+void executePeriodicTasks ( void ) {
 
-    static int periodicTaskIndex = 0;
+  static int periodicTaskIndex = 0;
 
-    switch (periodicTaskIndex++) {
+  switch ( periodicTaskIndex++ ) {
 #ifdef MAG
     case UPDATE_COMPASS_TASK:
-        if (sensors(SENSOR_MAG)) {
-            updateCompass(&masterConfig.magZero, &masterConfig.magScale);
-        }
-        break;
+      if ( sensors ( SENSOR_MAG ) ) {
+        updateCompass ( &masterConfig.magZero, &masterConfig.magScale );
+      }
+      break;
 #endif
 
 #ifdef BARO
     case UPDATE_BARO_TASK:
-        if (sensors(SENSOR_BARO)) {
+      if ( sensors ( SENSOR_BARO ) ) {
 
-            baroUpdate(currentTime);
-
-
-        }
-        break;
+        baroUpdate ( currentTime );
+      }
+      break;
 #endif
 
-#if defined(BARO) || defined(SONAR)
+#if defined( BARO ) || defined( SONAR )
     case CALCULATE_ALTITUDE_TASK:
-        if (true
-#if defined(BARO)
-                || (sensors(SENSOR_BARO) && isBaroReady())
-#endif
-#if defined(SONAR)
-                || sensors(SENSOR_SONAR)
-#endif
-                        ) {
+      if ( true
+  #if defined( BARO )
+           || ( sensors ( SENSOR_BARO ) && isBaroReady ( ) )
+  #endif
+  #if defined( SONAR )
+           || sensors ( SENSOR_SONAR )
+  #endif
+      ) {
 
-            if (!isCalibrating()) {
+        if ( ! isCalibrating ( ) ) {
 
-                apmCalculateEstimatedAltitude(currentTime);
+          apmCalculateEstimatedAltitude ( currentTime );
 
-                if (localisationType == UWB)
-                    PosXYEstimate(currentTime);
+          if ( localisationType == UWB )
+            PosXYEstimate ( currentTime );
 
-                isCalibrated = true;
-
-            }
-
-            else {
-
-                isCalibrated = false;
-
-            }
+          isCalibrated = true;
 
         }
-        break;
+
+        else {
+
+          isCalibrated = false;
+        }
+      }
+      break;
 #endif
 #ifdef SONAR
     case UPDATE_SONAR_TASK:
-        if (sensors(SENSOR_SONAR)) {
-            sonarUpdate();
-        }
-        break;
+      if ( sensors ( SENSOR_SONAR ) ) {
+        sonarUpdate ( );
+      }
+      break;
 #endif
 #ifdef DISPLAY
     case UPDATE_DISPLAY_TASK:
-        if (feature(FEATURE_DISPLAY)) {
-            updateDisplay();
-        }
-        break;
+      if ( feature ( FEATURE_DISPLAY ) ) {
+        updateDisplay ( );
+      }
+      break;
 #endif
 
     case UPDATE_OPTICFLOW:
 
 #ifdef OPTIC_FLOW
-        updateSpiOpticFlow();
-        runFlowHold(currentTime);
+      updateSpiOpticFlow ( );
+      runFlowHold ( currentTime );
 #endif
-        break;
+      break;
 
     case UPDATE_LASER_TOF_TASK:
 
 #ifdef LASER_TOF
 
-        getRange();
+      getRange ( );
 
 #endif
-//        if(useRangingSensor)
-//            getRange();
+      //        if(useRangingSensor)
+      //            getRange();
 
 
-        break;
+      break;
+  }
 
-    }
-
-    if (periodicTaskIndex >= PERIODIC_TASK_COUNT) {
-        periodicTaskIndex = 0;
-    }
-
+  if ( periodicTaskIndex >= PERIODIC_TASK_COUNT ) {
+    periodicTaskIndex = 0;
+  }
 }
 
-void processRx(void)
-{
+void processRx ( void ) {
 
-    static bool armedBeeperOn = false;
+  static bool armedBeeperOn = false;
 
-    calculateRxChannelsAndUpdateFailsafe(currentTime);
+  calculateRxChannelsAndUpdateFailsafe ( currentTime );
 
-    // in 3D mode, we need to be able to disarm by switch at any time
+  // in 3D mode, we need to be able to disarm by switch at any time
 
-    if (feature(FEATURE_3D)) {
-        if (!IS_RC_MODE_ACTIVE(BOXARM))
-            mwDisarm();
+  if ( feature ( FEATURE_3D ) ) {
+    if ( ! IS_RC_MODE_ACTIVE ( BOXARM ) )
+      mwDisarm ( );
+  }
+
+  updateRSSI ( currentTime );
+
+  if ( feature ( FEATURE_FAILSAFE ) ) {
+
+    if ( currentTime > FAILSAFE_POWER_ON_DELAY_US && ! failsafeIsMonitoring ( ) ) {
+      failsafeStartMonitoring ( );    // nothing much; monitering = true
     }
 
-    updateRSSI(currentTime);
+    failsafeUpdateState ( );
+  }
 
-    if (feature(FEATURE_FAILSAFE)) {
+  throttleStatus_e throttleStatus = calculateThrottleStatus ( &masterConfig.rxConfig, masterConfig.flight3DConfig.deadband3d_throttle );
 
-        if (currentTime > FAILSAFE_POWER_ON_DELAY_US && !failsafeIsMonitoring()) {
-            failsafeStartMonitoring();   //nothing much; monitering = true
-        }
+  if ( throttleStatus == THROTTLE_LOW ) {
+    pidResetErrorAngle ( );
+    pidResetErrorGyro ( );
+  }
 
-        failsafeUpdateState();
-    }
-
-    throttleStatus_e throttleStatus = calculateThrottleStatus(&masterConfig.rxConfig, masterConfig.flight3DConfig.deadband3d_throttle);
-
-    if (throttleStatus == THROTTLE_LOW) {
-        pidResetErrorAngle();
-        pidResetErrorGyro();
-    }
-
-    // When armed and motors aren't spinning, do beeps and then disarm
-    // board after delay so users without buzzer won't lose fingers.
-    // mixTable constrains motor commands, so checking  throttleStatus is enough
-    if (ARMING_FLAG(ARMED) && feature(FEATURE_MOTOR_STOP) && !STATE(FIXED_WING)) {
-        if (isUsingSticksForArming()) {
-            if (throttleStatus == THROTTLE_LOW) {
-                if (masterConfig.auto_disarm_delay != 0 && (int32_t)(disarmAt - millis()) < 0) {
-                    // auto-disarm configured and delay is over
-                    mwDisarm();
-                    armedBeeperOn = false;
-                } else {
-                    // still armed; do warning beeps while armed
-                    beeper(BEEPER_ARMED);
-                    armedBeeperOn = true;
-                }
-            } else {
-                // throttle is not low
-                if (masterConfig.auto_disarm_delay != 0) {
-                    // extend disarm time
-                    disarmAt = millis() + masterConfig.auto_disarm_delay * 1000;
-                }
-
-                if (armedBeeperOn) {
-                    beeperSilence();
-                    armedBeeperOn = false;
-                }
-            }
+  // When armed and motors aren't spinning, do beeps and then disarm
+  // board after delay so users without buzzer won't lose fingers.
+  // mixTable constrains motor commands, so checking  throttleStatus is enough
+  if ( ARMING_FLAG ( ARMED ) && feature ( FEATURE_MOTOR_STOP ) && ! STATE ( FIXED_WING ) ) {
+    if ( isUsingSticksForArming ( ) ) {
+      if ( throttleStatus == THROTTLE_LOW ) {
+        if ( masterConfig.auto_disarm_delay != 0 && ( int32_t ) ( disarmAt - millis ( ) ) < 0 ) {
+          // auto-disarm configured and delay is over
+          mwDisarm ( );
+          armedBeeperOn = false;
         } else {
-            // arming is via AUX switch; beep while throttle low
-            if (throttleStatus == THROTTLE_LOW) {
-                beeper(BEEPER_ARMED);
-                armedBeeperOn = true;
-            } else if (armedBeeperOn) {
-                beeperSilence();
-                armedBeeperOn = false;
-            }
+          // still armed; do warning beeps while armed
+          beeper ( BEEPER_ARMED );
+          armedBeeperOn = true;
         }
-    }
-
-    processRcStickPositions(&masterConfig.rxConfig, throttleStatus, masterConfig.retarded_arm, masterConfig.disarm_kill_switch);
-
-    if (feature(FEATURE_INFLIGHT_ACC_CAL)) {
-        updateInflightCalibrationState();
-    }
-
-    updateActivatedModes(currentProfile->modeActivationConditions);
-
-    if (!cliMode) {
-        updateAdjustmentStates(currentProfile->adjustmentRanges);
-        processRcAdjustments(currentControlRateProfile, &masterConfig.rxConfig);
-    }
-
-    bool canUseHorizonMode = true;
-
-    if ((IS_RC_MODE_ACTIVE(BOXANGLE) || (feature(FEATURE_FAILSAFE) && failsafeIsActive())) && (sensors(SENSOR_ACC))) {
-        // bumpless transfer to Level mode
-        canUseHorizonMode = false;
-
-        if (!FLIGHT_MODE(ANGLE_MODE)) {
-            pidResetErrorAngle();
-            ENABLE_FLIGHT_MODE(ANGLE_MODE);
+      } else {
+        // throttle is not low
+        if ( masterConfig.auto_disarm_delay != 0 ) {
+          // extend disarm time
+          disarmAt = millis ( ) + masterConfig.auto_disarm_delay * 1000;
         }
+
+        if ( armedBeeperOn ) {
+          beeperSilence ( );
+          armedBeeperOn = false;
+        }
+      }
     } else {
-        DISABLE_FLIGHT_MODE(ANGLE_MODE); // failsafe support
+      // arming is via AUX switch; beep while throttle low
+      if ( throttleStatus == THROTTLE_LOW ) {
+        beeper ( BEEPER_ARMED );
+        armedBeeperOn = true;
+      } else if ( armedBeeperOn ) {
+        beeperSilence ( );
+        armedBeeperOn = false;
+      }
     }
+  }
 
-    if (IS_RC_MODE_ACTIVE(BOXHORIZON) && canUseHorizonMode) {
+  processRcStickPositions ( &masterConfig.rxConfig, throttleStatus, masterConfig.retarded_arm, masterConfig.disarm_kill_switch );
 
-        DISABLE_FLIGHT_MODE(ANGLE_MODE);
+  if ( feature ( FEATURE_INFLIGHT_ACC_CAL ) ) {
+    updateInflightCalibrationState ( );
+  }
 
-        if (!FLIGHT_MODE(HORIZON_MODE)) {
-            pidResetErrorAngle();
-            ENABLE_FLIGHT_MODE(HORIZON_MODE);
-        }
+  updateActivatedModes ( currentProfile->modeActivationConditions );
+
+  if ( ! cliMode ) {
+    updateAdjustmentStates ( currentProfile->adjustmentRanges );
+    processRcAdjustments ( currentControlRateProfile, &masterConfig.rxConfig );
+  }
+
+  bool canUseHorizonMode = true;
+
+  if ( ( IS_RC_MODE_ACTIVE ( BOXANGLE ) || ( feature ( FEATURE_FAILSAFE ) && failsafeIsActive ( ) ) ) && ( sensors ( SENSOR_ACC ) ) ) {
+    // bumpless transfer to Level mode
+    canUseHorizonMode = false;
+
+    if ( ! FLIGHT_MODE ( ANGLE_MODE ) ) {
+      pidResetErrorAngle ( );
+      ENABLE_FLIGHT_MODE ( ANGLE_MODE );
+    }
+  } else {
+    DISABLE_FLIGHT_MODE ( ANGLE_MODE );    // failsafe support
+  }
+
+  if ( IS_RC_MODE_ACTIVE ( BOXHORIZON ) && canUseHorizonMode ) {
+
+    DISABLE_FLIGHT_MODE ( ANGLE_MODE );
+
+    if ( ! FLIGHT_MODE ( HORIZON_MODE ) ) {
+      pidResetErrorAngle ( );
+      ENABLE_FLIGHT_MODE ( HORIZON_MODE );
+    }
+  } else {
+    DISABLE_FLIGHT_MODE ( HORIZON_MODE );
+  }
+
+#ifdef MAG
+  if ( ! ARMING_FLAG ( ARMED ) && ( FLIGHT_MODE ( MAG_MODE ) || FLIGHT_MODE ( HEADFREE_MODE ) ) ) {
+    magHold = heading;    // initialization
+  }
+  if ( sensors ( SENSOR_ACC ) || sensors ( SENSOR_MAG ) ) {
+    if ( IS_RC_MODE_ACTIVE ( BOXMAG ) ) {
+      if ( ! FLIGHT_MODE ( MAG_MODE ) ) {
+        ENABLE_FLIGHT_MODE ( MAG_MODE );
+        magHold = heading;    // in flight initialization
+      }
     } else {
-        DISABLE_FLIGHT_MODE(HORIZON_MODE);
+      DISABLE_FLIGHT_MODE ( MAG_MODE );
+    }
+    if ( IS_RC_MODE_ACTIVE ( BOXHEADFREE ) ) {
+      if ( ! FLIGHT_MODE ( HEADFREE_MODE ) ) {
+        ENABLE_FLIGHT_MODE ( HEADFREE_MODE );
+      }
+    } else {
+      DISABLE_FLIGHT_MODE ( HEADFREE_MODE );
+    }
+    if ( IS_RC_MODE_ACTIVE ( BOXHEADADJ ) ) {
+      headFreeModeHold = heading;    // acquire new heading
     }
 
-#ifdef  MAG
-    if (!ARMING_FLAG(ARMED) && (FLIGHT_MODE(MAG_MODE) || FLIGHT_MODE(HEADFREE_MODE))) {
-        magHold = heading;  //initialization
+    // Used while inFligght Mode change
+    if ( IS_RC_MODE_ACTIVE ( BOXBARO ) && ! isHeadSet ) {
+      headFreeModeHold = heading;    // acquire new heading
+      isHeadSet        = true;
     }
-    if (sensors(SENSOR_ACC) || sensors(SENSOR_MAG)) {
-        if (IS_RC_MODE_ACTIVE(BOXMAG)) {
-            if (!FLIGHT_MODE(MAG_MODE)) {
-                ENABLE_FLIGHT_MODE(MAG_MODE);
-                magHold = heading;  //in flight initialization
-            }
-        } else {
-            DISABLE_FLIGHT_MODE(MAG_MODE);
-        }
-        if (IS_RC_MODE_ACTIVE(BOXHEADFREE)) {
-            if (!FLIGHT_MODE(HEADFREE_MODE)) {
-                ENABLE_FLIGHT_MODE(HEADFREE_MODE);
-            }
-        } else {
-            DISABLE_FLIGHT_MODE(HEADFREE_MODE);
-        }
-        if (IS_RC_MODE_ACTIVE(BOXHEADADJ)) {
-            headFreeModeHold = heading; // acquire new heading
-        }
 
-        // Used while inFligght Mode change
-        if (IS_RC_MODE_ACTIVE(BOXBARO) && !isHeadSet) {
-            headFreeModeHold = heading; // acquire new heading
-            isHeadSet = true;
-        }
+    if ( ! IS_RC_MODE_ACTIVE ( BOXBARO ) ) {
 
-        if (!IS_RC_MODE_ACTIVE(BOXBARO)) {
-
-            isHeadSet = false;
-        }
-
+      isHeadSet = false;
     }
+  }
 #endif
 
 #ifdef GPS
-    if (sensors(SENSOR_GPS)) {
+  if ( sensors ( SENSOR_GPS ) ) {
 
-        updateGpsWaypointsAndMode();
-    }
+    updateGpsWaypointsAndMode ( );
+  }
 #endif
 
-    if (IS_RC_MODE_ACTIVE(BOXPASSTHRU)) {
-        ENABLE_FLIGHT_MODE(PASSTHRU_MODE);
-    } else {
-        DISABLE_FLIGHT_MODE(PASSTHRU_MODE);
-    }
+  if ( IS_RC_MODE_ACTIVE ( BOXPASSTHRU ) ) {
+    ENABLE_FLIGHT_MODE ( PASSTHRU_MODE );
+  } else {
+    DISABLE_FLIGHT_MODE ( PASSTHRU_MODE );
+  }
 
-    if (masterConfig.mixerMode == MIXER_FLYING_WING || masterConfig.mixerMode == MIXER_AIRPLANE) {
-        DISABLE_FLIGHT_MODE(HEADFREE_MODE);
-    }
+  if ( masterConfig.mixerMode == MIXER_FLYING_WING || masterConfig.mixerMode == MIXER_AIRPLANE ) {
+    DISABLE_FLIGHT_MODE ( HEADFREE_MODE );
+  }
 
 #ifdef TELEMETRY
-    if (feature(FEATURE_TELEMETRY)) {
-        if ((!masterConfig.telemetryConfig.telemetry_switch && ARMING_FLAG(ARMED)) || (masterConfig.telemetryConfig.telemetry_switch && IS_RC_MODE_ACTIVE(BOXTELEMETRY))) {
+  if ( feature ( FEATURE_TELEMETRY ) ) {
+    if ( ( ! masterConfig.telemetryConfig.telemetry_switch && ARMING_FLAG ( ARMED ) ) || ( masterConfig.telemetryConfig.telemetry_switch && IS_RC_MODE_ACTIVE ( BOXTELEMETRY ) ) ) {
 
-            releaseSharedTelemetryPorts();
+      releaseSharedTelemetryPorts ( );
 
-        } else {
-            // the telemetry state must be checked immediately so that shared serial ports are released.
-            telemetryCheckState();
-            mspAllocateSerialPorts(&masterConfig.serialConfig);
-        }
+    } else {
+      // the telemetry state must be checked immediately so that shared serial ports are released.
+      telemetryCheckState ( );
+      mspAllocateSerialPorts ( &masterConfig.serialConfig );
     }
+  }
 #endif
-
 }
 
-void filterRc(void)
-{
-    static int16_t lastCommand[4] = { 0, 0, 0, 0 };
-    static int16_t deltaRC[4] = { 0, 0, 0, 0 };
-    static int16_t factor, rcInterpolationFactor;
-    static filterStatePt1_t filteredCycleTimeState;
-    uint16_t rxRefreshRate, filteredCycleTime;
+void filterRc ( void ) {
+  static int16_t lastCommand [ 4 ] = { 0, 0, 0, 0 };
+  static int16_t deltaRC [ 4 ]     = { 0, 0, 0, 0 };
+  static int16_t factor, rcInterpolationFactor;
+  static filterStatePt1_t filteredCycleTimeState;
+  uint16_t rxRefreshRate, filteredCycleTime;
 
-    // Set RC refresh rate for sampling and channels to filter
-    initRxRefreshRate(&rxRefreshRate);
+  // Set RC refresh rate for sampling and channels to filter
+  initRxRefreshRate ( &rxRefreshRate );
 
-    filteredCycleTime = filterApplyPt1(cycleTime, &filteredCycleTimeState, 1);
-    rcInterpolationFactor = rxRefreshRate / filteredCycleTime + 1;
+  filteredCycleTime     = filterApplyPt1 ( cycleTime, &filteredCycleTimeState, 1 );
+  rcInterpolationFactor = rxRefreshRate / filteredCycleTime + 1;
 
-    if (isRXDataNew) {
-        for (int channel = 0; channel < 4; channel++) {
-            deltaRC[channel] = rcCommand[channel] - (lastCommand[channel] - deltaRC[channel] * factor / rcInterpolationFactor);
-            lastCommand[channel] = rcCommand[channel];
-        }
-
-        isRXDataNew = false;
-        factor = rcInterpolationFactor - 1;
-    } else {
-        factor--;
+  if ( isRXDataNew ) {
+    for ( int channel = 0; channel < 4; channel++ ) {
+      deltaRC [ channel ]     = rcCommand [ channel ] - ( lastCommand [ channel ] - deltaRC [ channel ] * factor / rcInterpolationFactor );
+      lastCommand [ channel ] = rcCommand [ channel ];
     }
 
-    // Interpolate steps of rcCommand
-    if (factor > 0) {
-        for (int channel = 0; channel < 4; channel++) {
-            rcCommand[channel] = lastCommand[channel] - deltaRC[channel] * factor / rcInterpolationFactor;
-        }
-    } else {
-        factor = 0;
+    isRXDataNew = false;
+    factor      = rcInterpolationFactor - 1;
+  } else {
+    factor--;
+  }
+
+  // Interpolate steps of rcCommand
+  if ( factor > 0 ) {
+    for ( int channel = 0; channel < 4; channel++ ) {
+      rcCommand [ channel ] = lastCommand [ channel ] - deltaRC [ channel ] * factor / rcInterpolationFactor;
     }
+  } else {
+    factor = 0;
+  }
 }
 
-void userCode()
-{
+void userCode ( ) {
 
-    if ((rcData[AUX2] == 1500 && rxIsReceivingSignal())) {
-        runUserCode = true;
+  if ( ( rcData [ DevModeAUX ] >= DevModeMinRange && rcData [ DevModeAUX ] <= DevModeMaxRange ) && ( rxIsReceivingSignal ( ) || ppmIsRecievingSignal ( ) ) ) {
+    runUserCode = true;
 
-    } else {
-        runUserCode = false;
-
-    }
+  } else {
+    runUserCode = false;
+  }
 
     if (runUserCode) {
-
-        userCurrentTime = micros();
-        if ((int32_t)(userCurrentTime - userLoopTime) >= 0) {
-            {
-                userLoopTime = userCurrentTime + userLoopFrequency;    //100ms default
-                if (callOnPilotStart) {
-                    onLoopStart();
-                    callOnPilotStart = false;
-                    callonPilotFinish = true;
-                }
-
-                plutoLoop();
-
-            }
-        } else {
-
-            for (int i = 0; i < 4; i++) {
-
-                if (userRCflag[i]) {
-
-                    if (i < 3)
-                        rcCommand[i] = RC_ARRAY[i];
-                    else if (i == 3)
-                        rcData[i] = RC_ARRAY[i];
-
-                }
-            }
-
-            if (isUserHeadingSet) {
-
-                magHold = userHeading;
-
-            }
-
-            for (int i = 0; i < 6; i++) {
-
-                if (isUserFlightModeSet[i])
-                    FlightMode.set((flight_mode_e) i);
-
-            }
-
+    userCurrentTime = micros ( );
+    if ( ( int32_t ) ( userCurrentTime - userLoopTime ) >= 0 ) {
+      {
+        userLoopTime = userCurrentTime + userLoopFrequency;    // 100ms default
+        if ( callOnPilotStart ) {
+          onLoopStart ( );
+          callOnPilotStart  = false;
+          callonPilotFinish = true;
         }
+
+        plutoLoop ( );
+      }
+    } else {
+
+      for ( int i = 0; i < 4; i++ ) {
+
+        if ( userRCflag [ i ] ) {
+
+          if ( i < 3 )
+            rcCommand [ i ] = RC_ARRAY [ i ];
+          else if ( i == 3 )
+            rcData [ i ] = RC_ARRAY [ i ];
+        }
+      }
+
+      if ( isUserHeadingSet ) {
+
+        magHold = userHeading;
+      }
+
+      for ( int i = 0; i < 6; i++ ) {
+
+        if ( isUserFlightModeSet [ i ] )
+          FlightMode.set ( ( flight_mode_e ) i );
+      }
+    }
 
     }
 
     else {
+    if ( callonPilotFinish ) {
+      for ( int i = 0; i < 4; i++ ) {
+        RC_ARRAY [ i ]   = 0;
+        userRCflag [ i ] = false;
+      }
 
-        if (callonPilotFinish) {
-            for (int i = 0; i < 4; i++) {
-                RC_ARRAY[i] = 0;
-                userRCflag[i] = false;
-
-            }
-
-            isUserHeadingSet = false;
-            onLoopFinish();
-            callOnPilotStart = true;
-            callonPilotFinish = false;
-
-        }
-
+      isUserHeadingSet = false;
+      onLoopFinish ( );
+      callOnPilotStart  = true;
+      callonPilotFinish = false;
     }
 
+    }
 }
 
-void loop(void)
-{
+void loop ( void ) {
 
-    static uint32_t loopTime;
-#if defined(BARO) || defined(SONAR)
-    static bool haveProcessedAnnexCodeOnce = false;
+  static uint32_t loopTime;
+#if defined( BARO ) || defined( SONAR )
+  static bool haveProcessedAnnexCodeOnce = false;
 #endif
 
-    updateRx(currentTime);
+  updateRx ( currentTime );
 
 #ifdef FLIGHT_STATUS_INDICATOR
-    flightStatusIndicator();
+  flightStatusIndicator ( );
 #endif
 
-    if (shouldProcessRx(currentTime)) {
-        processRx();
-        isRXDataNew = true;
+  if ( shouldProcessRx ( currentTime ) ) {
+    processRx ( );
+    isRXDataNew = true;
 
 #ifdef BARO
-        // the 'annexCode' initialses rcCommand, updateAltHoldState depends on valid rcCommand data.
-        if (haveProcessedAnnexCodeOnce) {
-            if (sensors(SENSOR_BARO)) {
-                updateAltHoldState();
-            }
-        }
+    // the 'annexCode' initialses rcCommand, updateAltHoldState depends on valid rcCommand data.
+    if ( haveProcessedAnnexCodeOnce ) {
+      if ( sensors ( SENSOR_BARO ) ) {
+        updateAltHoldState ( );
+      }
+    }
 #endif
 
 #ifdef SONAR
-        // the 'annexCode' initialses rcCommand, updateAltHoldState depends on valid rcCommand data.
-        if (haveProcessedAnnexCodeOnce) {
-            if (sensors(SENSOR_SONAR)) {
-                updateSonarAltHoldState();
-            }
-        }
+    // the 'annexCode' initialses rcCommand, updateAltHoldState depends on valid rcCommand data.
+    if ( haveProcessedAnnexCodeOnce ) {
+      if ( sensors ( SENSOR_SONAR ) ) {
+        updateSonarAltHoldState ( );
+      }
+    }
 #endif
+
+  } else {
+    // not processing rx this iteration
+
+    executePeriodicTasks ( );
+
+    // if GPS feature is enabled, gpsThread() will be called at some intervals to check for stuck
+    // hardware, wrong baud rates, init GPS if needed, etc. Don't use SENSOR_GPS here as gpsThread() can and will
+    // change this based on available hardware
+#ifdef GPS
+    if ( feature ( FEATURE_GPS ) ) {
+      gpsThread ( );
+    }
+#endif
+  }
+
+  currentTime = micros ( );
+  if ( masterConfig.looptime == 0 || ( int32_t ) ( currentTime - loopTime ) >= 0 ) {
+    loopTime = currentTime + masterConfig.looptime;
+
+    imuUpdate ( &currentProfile->accelerometerTrims );
+
+    // Measure loop rate just after reading the sensors
+    currentTime  = micros ( );
+    cycleTime    = ( int32_t ) ( currentTime - previousTime );
+    previousTime = currentTime;
+
+#ifdef ENABLE_ACROBAT
+    if ( ARMING_FLAG ( ARMED ) ) {
+      if ( flipState >= 1 ) {
+        flip ( true );
+      }
 
     } else {
-        // not processing rx this iteration
-
-        executePeriodicTasks();
-
-        // if GPS feature is enabled, gpsThread() will be called at some intervals to check for stuck
-        // hardware, wrong baud rates, init GPS if needed, etc. Don't use SENSOR_GPS here as gpsThread() can and will
-        // change this based on available hardware
-#ifdef GPS
-        if (feature(FEATURE_GPS)) {
-            gpsThread();
-        }
+      flip ( false );
+    }
 #endif
+
+    // Gyro Low Pass
+    if ( currentProfile->pidProfile.gyro_cut_hz ) {
+      int axis;
+      static filterStatePt1_t gyroADCState [ XYZ_AXIS_COUNT ];
+
+      for ( axis = 0; axis < XYZ_AXIS_COUNT; axis++ ) {
+        gyroADC [ axis ] = filterApplyPt1 ( gyroADC [ axis ], &gyroADCState [ axis ], currentProfile->pidProfile.gyro_cut_hz );
+      }
     }
 
-    currentTime = micros();
-    if (masterConfig.looptime == 0 || (int32_t)(currentTime - loopTime) >= 0) {
-        loopTime = currentTime + masterConfig.looptime;
-
-        imuUpdate(&currentProfile->accelerometerTrims);
-
-        // Measure loop rate just after reading the sensors
-        currentTime = micros();
-        cycleTime = (int32_t)(currentTime - previousTime);
-        previousTime = currentTime;
-
-#ifdef  ENABLE_ACROBAT
-        if(ARMING_FLAG(ARMED)) {
-            if(flipState >= 1) {
-                flip(true);
-            }
-
-        }
-        else {
-            flip(false);
-        }
-#endif
-
-        // Gyro Low Pass
-        if (currentProfile->pidProfile.gyro_cut_hz) {
-            int axis;
-            static filterStatePt1_t gyroADCState[XYZ_AXIS_COUNT];
-
-            for (axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-                gyroADC[axis] = filterApplyPt1(gyroADC[axis], &gyroADCState[axis], currentProfile->pidProfile.gyro_cut_hz);
-            }
-        }
-
 #ifdef UWB
-        if (localisationType == UWB)
-            uwbUpdate();
+    if ( localisationType == UWB )
+      uwbUpdate ( );
 #endif
 
-        annexCode();
+    annexCode ( );
 
-        if (masterConfig.rxConfig.rcSmoothing) {
-            filterRc();
-        }
+    if ( masterConfig.rxConfig.rcSmoothing ) {
+      filterRc ( );
+    }
 
-        userCode();
+    userCode ( );
 
-        /* used in localisation
-         if (command_verify()){
+    /* used in localisation
+     if (command_verify()){
 
-         command_next();
+     command_next();
 
-         }
+     }
 
-         command_run(currentTime);
-         */
+     command_run(currentTime);
+     */
 
-#if defined(BARO) || defined(SONAR)
-        haveProcessedAnnexCodeOnce = true;
+#if defined( BARO ) || defined( SONAR )
+    haveProcessedAnnexCodeOnce = true;
 #endif
 
 #ifdef MAG
-        if (sensors(SENSOR_MAG)) {
-            updateMagHold();
-        }
+    if ( sensors ( SENSOR_MAG ) ) {
+      updateMagHold ( );
+    }
 #endif
 
 #ifdef OPTIC_FLOW
-        selectVelOrPosmode();
+    selectVelOrPosmode ( );
 #endif
 
 
 #ifdef GTUNE
-        updateGtuneState();
+    updateGtuneState ( );
 #endif
 
-#if defined(BARO) || defined(SONAR)
-        if (sensors(SENSOR_BARO) || sensors(SENSOR_SONAR)) {
-            if (FLIGHT_MODE(BARO_MODE) || FLIGHT_MODE(SONAR_MODE)) {
-                applyAltHold(&masterConfig.airplaneConfig);
-            }
-        }
+#if defined( BARO ) || defined( SONAR )
+    if ( sensors ( SENSOR_BARO ) || sensors ( SENSOR_SONAR ) ) {
+      if ( FLIGHT_MODE ( BARO_MODE ) || FLIGHT_MODE ( SONAR_MODE ) ) {
+        applyAltHold ( &masterConfig.airplaneConfig );
+      }
+    }
 #endif
 
-        // If we're armed, at minimum throttle, and we do arming via the
-        // sticks, do not process yaw input from the rx.  We do this so the
-        // motors do not spin up while we are trying to arm or disarm.
-        // Allow yaw control for tricopters if the user wants the servo to move even when unarmed.
-        if (isUsingSticksForArming() && rcData[THROTTLE] <= masterConfig.rxConfig.mincheck
+    // If we're armed, at minimum throttle, and we do arming via the
+    // sticks, do not process yaw input from the rx.  We do this so the
+    // motors do not spin up while we are trying to arm or disarm.
+    // Allow yaw control for tricopters if the user wants the servo to move even when unarmed.
+    if ( isUsingSticksForArming ( ) && rcData [ THROTTLE ] <= masterConfig.rxConfig.mincheck
 #ifndef USE_QUAD_MIXER_ONLY
-                && !((masterConfig.mixerMode == MIXER_TRI || masterConfig.mixerMode == MIXER_CUSTOM_TRI) && masterConfig.mixerConfig.tri_unarmed_servo) && masterConfig.mixerMode != MIXER_AIRPLANE && masterConfig.mixerMode != MIXER_FLYING_WING
+         && ! ( ( masterConfig.mixerMode == MIXER_TRI || masterConfig.mixerMode == MIXER_CUSTOM_TRI ) && masterConfig.mixerConfig.tri_unarmed_servo ) && masterConfig.mixerMode != MIXER_AIRPLANE && masterConfig.mixerMode != MIXER_FLYING_WING
 #endif
-                        ) {
-            rcCommand[YAW] = 0;
-        }
+    ) {
+      rcCommand [ YAW ] = 0;
+    }
 
-        if (currentProfile->throttle_correction_value && (FLIGHT_MODE(ANGLE_MODE) || FLIGHT_MODE(HORIZON_MODE))) {
-            rcCommand[THROTTLE] += calculateThrottleAngleCorrection(currentProfile->throttle_correction_value);
-        }
+    if ( currentProfile->throttle_correction_value && ( FLIGHT_MODE ( ANGLE_MODE ) || FLIGHT_MODE ( HORIZON_MODE ) ) ) {
+      rcCommand [ THROTTLE ] += calculateThrottleAngleCorrection ( currentProfile->throttle_correction_value );
+    }
 
 #ifdef GPS
-        if (sensors(SENSOR_GPS)) {
-            if ((FLIGHT_MODE(GPS_HOME_MODE) || FLIGHT_MODE(GPS_HOLD_MODE)) && STATE(GPS_FIX_HOME)) {
-                updateGpsStateForHomeAndHoldMode();
-            }
-        }
+    if ( sensors ( SENSOR_GPS ) ) {
+      if ( ( FLIGHT_MODE ( GPS_HOME_MODE ) || FLIGHT_MODE ( GPS_HOLD_MODE ) ) && STATE ( GPS_FIX_HOME ) ) {
+        updateGpsStateForHomeAndHoldMode ( );
+      }
+    }
 #endif
 
-        // PID - note this is function pointer set by setPIDController()
-        pid_controller(&currentProfile->pidProfile, currentControlRateProfile, masterConfig.max_angle_inclination, &currentProfile->accelerometerTrims, &masterConfig.rxConfig);
+    // PID - note this is function pointer set by setPIDController()
+    pid_controller ( &currentProfile->pidProfile, currentControlRateProfile, masterConfig.max_angle_inclination, &currentProfile->accelerometerTrims, &masterConfig.rxConfig );
 
-        mixTable();
+    mixTable ( );
 
 #ifdef USE_SERVOS
-        //   filterServos();
-        //   writeServos();
+    //   filterServos();
+    //   writeServos();
 #endif
 
-        if (motorControlEnable) {
-            writeMotors();
-        }
+    if ( motorControlEnable ) {
+      writeMotors ( );
+    }
 
 #ifdef BLACKBOX
-        if (!cliMode && feature(FEATURE_BLACKBOX)) {
-            handleBlackbox();
-        }
+    if ( ! cliMode && feature ( FEATURE_BLACKBOX ) ) {
+      handleBlackbox ( );
+    }
 #endif
 
-        /*
-         #ifdef BAROO
-         // the 'annexCode' initialses rcCommand, updateAltHoldState depends on valid rcCommand data.
-         if (haveProcessedAnnexCodeOnce) {
-         if (sensors(SENSOR_BARO)) {
-         updateAltHoldState();
-         }
-         }
-         #endif
-         */
+    /*
+     #ifdef BAROO
+     // the 'annexCode' initialses rcCommand, updateAltHoldState depends on valid rcCommand data.
+     if (haveProcessedAnnexCodeOnce) {
+     if (sensors(SENSOR_BARO)) {
+     updateAltHoldState();
+     }
+     }
+     #endif
+     */
 
-        failsafeOnCrash();
+    failsafeOnCrash ( );
 
-        executeCommand();
-
-    }
+    executeCommand ( );
+  }
 
 #ifdef TELEMETRY
-    if (!cliMode && feature(FEATURE_TELEMETRY)) {
-        telemetryProcess(&masterConfig.rxConfig, masterConfig.flight3DConfig.deadband3d_throttle);
-    }
+  if ( ! cliMode && feature ( FEATURE_TELEMETRY ) ) {
+    telemetryProcess ( &masterConfig.rxConfig, masterConfig.flight3DConfig.deadband3d_throttle );
+  }
 #endif
 
 #ifdef LED_STRIP
-    if (feature(FEATURE_LED_STRIP)) {
-        updateLedStrip();
-    }
+  if ( feature ( FEATURE_LED_STRIP ) ) {
+    updateLedStrip ( );
+  }
 #endif
 
 #ifdef OPTIC_FLOW
-    if (runUserCode) {
+  if ( runUserCode ) {
 
-        isLocalisationOn = true;
+    isLocalisationOn = true;
 
-    } else {
+  } else {
 
-        isLocalisationOn = false;
-
-    }
+    isLocalisationOn = false;
+  }
 #endif
-
-
-
-
 }

--- a/src/main/rx/rx.cpp
+++ b/src/main/rx/rx.cpp
@@ -289,6 +289,10 @@ bool rxIsReceivingSignal(void)
     return rxSignalReceived;
 }
 
+bool ppmIsRecievingSignal(void){
+  return rxSignalReceivedNotDataDriven;
+}
+
 bool rxAreFlightChannelsValid(void)
 {
     return rxFlightChannelsValid;

--- a/src/main/rx/rx.h
+++ b/src/main/rx/rx.h
@@ -19,149 +19,151 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif 
+#endif
 
-#define STICK_CHANNEL_COUNT 4
+#define STICK_CHANNEL_COUNT                          4
 
-#define PWM_RANGE_ZERO 0 // FIXME should all usages of this be changed to use PWM_RANGE_MIN?
-#define PWM_RANGE_MIN 1000
-#define PWM_RANGE_MAX 2000
-#define PWM_RANGE_MIDDLE (PWM_RANGE_MIN + ((PWM_RANGE_MAX - PWM_RANGE_MIN) / 2))
+#define PWM_RANGE_ZERO                               0    // FIXME should all usages of this be changed to use PWM_RANGE_MIN?
+#define PWM_RANGE_MIN                                1000
+#define PWM_RANGE_MAX                                2000
+#define PWM_RANGE_MIDDLE                             ( PWM_RANGE_MIN + ( ( PWM_RANGE_MAX - PWM_RANGE_MIN ) / 2 ) )
 
-#define PWM_PULSE_MIN   750       // minimum PWM pulse width which is considered valid
-#define PWM_PULSE_MAX   2250      // maximum PWM pulse width which is considered valid
+#define PWM_PULSE_MIN                                750     // minimum PWM pulse width which is considered valid
+#define PWM_PULSE_MAX                                2250    // maximum PWM pulse width which is considered valid
 
-#define RXFAIL_STEP_TO_CHANNEL_VALUE(step) (PWM_PULSE_MIN + 25 * step)
-#define CHANNEL_VALUE_TO_RXFAIL_STEP(channelValue) ((constrain(channelValue, PWM_PULSE_MIN, PWM_PULSE_MAX) - PWM_PULSE_MIN) / 25)
-#define MAX_RXFAIL_RANGE_STEP ((PWM_PULSE_MAX - PWM_PULSE_MIN) / 25)
+#define RXFAIL_STEP_TO_CHANNEL_VALUE( step )         ( PWM_PULSE_MIN + 25 * step )
+#define CHANNEL_VALUE_TO_RXFAIL_STEP( channelValue ) ( ( constrain ( channelValue, PWM_PULSE_MIN, PWM_PULSE_MAX ) - PWM_PULSE_MIN ) / 25 )
+#define MAX_RXFAIL_RANGE_STEP                        ( ( PWM_PULSE_MAX - PWM_PULSE_MIN ) / 25 )
 
-#define DEFAULT_SERVO_MIN 1000
-#define DEFAULT_SERVO_MIDDLE 1500
-#define DEFAULT_SERVO_MAX 2000
-#define DEFAULT_SERVO_MIN_ANGLE 90
-#define DEFAULT_SERVO_MAX_ANGLE 90
+#define DEFAULT_SERVO_MIN                            1000
+#define DEFAULT_SERVO_MIDDLE                         1500
+#define DEFAULT_SERVO_MAX                            2000
+#define DEFAULT_SERVO_MIN_ANGLE                      90
+#define DEFAULT_SERVO_MAX_ANGLE                      90
 
 typedef enum {
-    SERIAL_RX_FRAME_PENDING = 0,
-    SERIAL_RX_FRAME_COMPLETE = (1 << 0),
-    SERIAL_RX_FRAME_FAILSAFE = (1 << 1)
+  SERIAL_RX_FRAME_PENDING  = 0,
+  SERIAL_RX_FRAME_COMPLETE = ( 1 << 0 ),
+  SERIAL_RX_FRAME_FAILSAFE = ( 1 << 1 )
 } serialrxFrameState_t;
 
 typedef enum {
-    SERIALRX_SPEKTRUM1024 = 0,
-    SERIALRX_SPEKTRUM2048 = 1,
-    SERIALRX_SBUS = 2,
-    SERIALRX_SUMD = 3,
-    SERIALRX_SUMH = 4,
-    SERIALRX_XBUS_MODE_B = 5,
-    SERIALRX_XBUS_MODE_B_RJ01 = 6,
-    SERIALRX_PROVIDER_MAX = SERIALRX_XBUS_MODE_B_RJ01
+  SERIALRX_SPEKTRUM1024     = 0,
+  SERIALRX_SPEKTRUM2048     = 1,
+  SERIALRX_SBUS             = 2,
+  SERIALRX_SUMD             = 3,
+  SERIALRX_SUMH             = 4,
+  SERIALRX_XBUS_MODE_B      = 5,
+  SERIALRX_XBUS_MODE_B_RJ01 = 6,
+  SERIALRX_PROVIDER_MAX     = SERIALRX_XBUS_MODE_B_RJ01
 } SerialRXType;
 
-#define SERIALRX_PROVIDER_COUNT (SERIALRX_PROVIDER_MAX + 1)
+#define SERIALRX_PROVIDER_COUNT                     ( SERIALRX_PROVIDER_MAX + 1 )
 
-#define MAX_SUPPORTED_RC_PPM_CHANNEL_COUNT 12
+#define MAX_SUPPORTED_RC_PPM_CHANNEL_COUNT          12
 #define MAX_SUPPORTED_RC_PARALLEL_PWM_CHANNEL_COUNT 8
-#define MAX_SUPPORTED_RC_CHANNEL_COUNT (18)
+#define MAX_SUPPORTED_RC_CHANNEL_COUNT              ( 18 )
 
-#define NON_AUX_CHANNEL_COUNT 4
-#define MAX_AUX_CHANNEL_COUNT (MAX_SUPPORTED_RC_CHANNEL_COUNT - NON_AUX_CHANNEL_COUNT)
+#define NON_AUX_CHANNEL_COUNT                       4
+#define MAX_AUX_CHANNEL_COUNT                       ( MAX_SUPPORTED_RC_CHANNEL_COUNT - NON_AUX_CHANNEL_COUNT )
 
 #if MAX_SUPPORTED_RC_PARALLEL_PWM_CHANNEL_COUNT > MAX_SUPPORTED_RC_PPM_CHANNEL_COUNT
-#define MAX_SUPPORTED_RX_PARALLEL_PWM_OR_PPM_CHANNEL_COUNT MAX_SUPPORTED_RC_PARALLEL_PWM_CHANNEL_COUNT
+  #define MAX_SUPPORTED_RX_PARALLEL_PWM_OR_PPM_CHANNEL_COUNT MAX_SUPPORTED_RC_PARALLEL_PWM_CHANNEL_COUNT
 #else
-#define MAX_SUPPORTED_RX_PARALLEL_PWM_OR_PPM_CHANNEL_COUNT MAX_SUPPORTED_RC_PPM_CHANNEL_COUNT
+  #define MAX_SUPPORTED_RX_PARALLEL_PWM_OR_PPM_CHANNEL_COUNT MAX_SUPPORTED_RC_PPM_CHANNEL_COUNT
 #endif
 
-extern const char rcChannelLetters[];
+extern const char rcChannelLetters [];
 
-extern int16_t rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];   // interval [1000;2000]
+extern int16_t rcData [ MAX_SUPPORTED_RC_CHANNEL_COUNT ];    // interval [1000;2000]
 
 #define MAX_MAPPABLE_RX_INPUTS 8
 
-#define RSSI_SCALE_MIN 1
-#define RSSI_SCALE_MAX 255
-#define RSSI_SCALE_DEFAULT 30
+#define RSSI_SCALE_MIN         1
+#define RSSI_SCALE_MAX         255
+#define RSSI_SCALE_DEFAULT     30
 
 typedef enum {
-    RX_FAILSAFE_MODE_AUTO = 0,
-    RX_FAILSAFE_MODE_HOLD,
-    RX_FAILSAFE_MODE_SET,
-    RX_FAILSAFE_MODE_INVALID,
+  RX_FAILSAFE_MODE_AUTO = 0,
+  RX_FAILSAFE_MODE_HOLD,
+  RX_FAILSAFE_MODE_SET,
+  RX_FAILSAFE_MODE_INVALID,
 } rxFailsafeChannelMode_e;
 
 #define RX_FAILSAFE_MODE_COUNT 3
 
 typedef enum {
-    RX_FAILSAFE_TYPE_FLIGHT = 0, RX_FAILSAFE_TYPE_AUX,
+  RX_FAILSAFE_TYPE_FLIGHT = 0,
+  RX_FAILSAFE_TYPE_AUX,
 } rxFailsafeChannelType_e;
 
 #define RX_FAILSAFE_TYPE_COUNT 2
 
 typedef struct rxFailsafeChannelConfiguration_s {
-    uint8_t mode; // See rxFailsafeChannelMode_e
-    uint8_t step;
+  uint8_t mode;    // See rxFailsafeChannelMode_e
+  uint8_t step;
 } rxFailsafeChannelConfiguration_t;
 
 typedef struct rxChannelRangeConfiguration_s {
-    uint16_t min;
-    uint16_t max;
+  uint16_t min;
+  uint16_t max;
 } rxChannelRangeConfiguration_t;
 
 typedef struct rxConfig_s {
-    uint8_t rcmap[MAX_MAPPABLE_RX_INPUTS]; // mapping of radio channels to internal RPYTA+ order
-    uint8_t serialrx_provider; // type of UART-based receiver (0 = spek 10, 1 = spek 11, 2 = sbus). Must be enabled by FEATURE_RX_SERIAL first.
-    uint8_t spektrum_sat_bind; // number of bind pulses for Spektrum satellite receivers
-    uint8_t rssi_channel;
-    uint8_t rssi_scale;
-    uint8_t rssi_ppm_invert;
-    uint8_t rcSmoothing;                    // Enable/Disable RC filtering
-    uint16_t midrc; // Some radios have not a neutral point centered on 1500. can be changed here
-    uint16_t mincheck;                      // minimum rc end
-    uint16_t maxcheck;                      // maximum rc end
+  uint8_t rcmap [ MAX_MAPPABLE_RX_INPUTS ];    // mapping of radio channels to internal RPYTA+ order
+  uint8_t serialrx_provider;                   // type of UART-based receiver (0 = spek 10, 1 = spek 11, 2 = sbus). Must be enabled by FEATURE_RX_SERIAL first.
+  uint8_t spektrum_sat_bind;                   // number of bind pulses for Spektrum satellite receivers
+  uint8_t rssi_channel;
+  uint8_t rssi_scale;
+  uint8_t rssi_ppm_invert;
+  uint8_t rcSmoothing;    // Enable/Disable RC filtering
+  uint16_t midrc;         // Some radios have not a neutral point centered on 1500. can be changed here
+  uint16_t mincheck;      // minimum rc end
+  uint16_t maxcheck;      // maximum rc end
 
-    uint16_t rx_min_usec;
-    uint16_t rx_max_usec;
-    rxFailsafeChannelConfiguration_t failsafe_channel_configurations[MAX_SUPPORTED_RC_CHANNEL_COUNT];
+  uint16_t rx_min_usec;
+  uint16_t rx_max_usec;
+  rxFailsafeChannelConfiguration_t failsafe_channel_configurations [ MAX_SUPPORTED_RC_CHANNEL_COUNT ];
 
-    rxChannelRangeConfiguration_t channelRanges[NON_AUX_CHANNEL_COUNT];
+  rxChannelRangeConfiguration_t channelRanges [ NON_AUX_CHANNEL_COUNT ];
 } rxConfig_t;
 
-#define REMAPPABLE_CHANNEL_COUNT (sizeof(((rxConfig_t *)0)->rcmap) / sizeof(((rxConfig_t *)0)->rcmap[0]))
+#define REMAPPABLE_CHANNEL_COUNT ( sizeof ( ( ( rxConfig_t * ) 0 )->rcmap ) / sizeof ( ( ( rxConfig_t * ) 0 )->rcmap [ 0 ] ) )
 
 typedef struct rxRuntimeConfig_s {
-    uint8_t channelCount; // number of rc channels as reported by current input driver
-    uint8_t auxChannelCount;
+  uint8_t channelCount;    // number of rc channels as reported by current input driver
+  uint8_t auxChannelCount;
 } rxRuntimeConfig_t;
 
 extern rxRuntimeConfig_t rxRuntimeConfig;
 
-void useRxConfig(rxConfig_t *rxConfigToUse);
+void useRxConfig ( rxConfig_t *rxConfigToUse );
 
-typedef uint16_t (*rcReadRawDataPtr)(rxRuntimeConfig_t *rxRuntimeConfig, uint8_t chan); // used by receiver driver to return channel data
+typedef uint16_t ( *rcReadRawDataPtr ) ( rxRuntimeConfig_t *rxRuntimeConfig, uint8_t chan );    // used by receiver driver to return channel data
 
-void updateRx(uint32_t currentTime);
-bool rxIsReceivingSignal(void);
-bool rxAreFlightChannelsValid(void);
-bool shouldProcessRx(uint32_t currentTime);
-void calculateRxChannelsAndUpdateFailsafe(uint32_t currentTime);
-
-
-void parseRcChannels(const char *input, rxConfig_t *rxConfig);
-uint8_t serialRxFrameStatus(rxConfig_t *rxConfig);
-
-void updateRSSI(uint32_t currentTime);
-void resetAllRxChannelRangeConfigurations(rxChannelRangeConfiguration_t *rxChannelRangeConfiguration);
+void updateRx ( uint32_t currentTime );
+bool rxIsReceivingSignal ( void );
+bool ppmIsRecievingSignal ( void );
+bool rxAreFlightChannelsValid ( void );
+bool shouldProcessRx ( uint32_t currentTime );
+void calculateRxChannelsAndUpdateFailsafe ( uint32_t currentTime );
 
 
-void suspendRxSignal(void);
-void resumeRxSignal(void);
+void parseRcChannels ( const char *input, rxConfig_t *rxConfig );
+uint8_t serialRxFrameStatus ( rxConfig_t *rxConfig );
 
-void initRxRefreshRate(uint16_t *rxRefreshRatePtr);
+void updateRSSI ( uint32_t currentTime );
+void resetAllRxChannelRangeConfigurations ( rxChannelRangeConfiguration_t *rxChannelRangeConfiguration );
+
+
+void suspendRxSignal ( void );
+void resumeRxSignal ( void );
+
+void initRxRefreshRate ( uint16_t *rxRefreshRatePtr );
 
 extern bool rc_connected;
 
 
 #ifdef __cplusplus
 }
-#endif 
+#endif


### PR DESCRIPTION
Introduced a new device mode (DEV mode) with configurable auxiliary channel, minimum and maximum range. Updated `rxMode` function to handle DEV mode in both Rx_ESP and Rx_PPM cases. Added global variables to store DEV mode configuration parameters. Implemented `configureDevMode` function to set up DEV mode when auxiliary changes are enabled. This enhancement allows more flexible control over custom device modes using the receiver's auxiliary channels.